### PR TITLE
Fix: Linux tray quit and zombie icons

### DIFF
--- a/src/ipc/process/handler.ts
+++ b/src/ipc/process/handler.ts
@@ -193,14 +193,18 @@ export async function closeAntigravity(): Promise<void> {
       if (p.cmd.includes('Antigravity Manager') || p.cmd.includes('antigravity-manager')) {
         return false;
       }
-      // Match Antigravity
+      // Match Antigravity (but not manager)
       if (platform === 'win32') {
         return (
           p.cmd.includes('Antigravity.exe') ||
           (p.cmd.includes('antigravity') && !p.cmd.includes('manager'))
         );
       } else {
-        return p.cmd.includes('Antigravity') || p.cmd.includes('antigravity');
+        // Explicit !manager check for Linux/macOS to be defensive
+        return (
+          (p.cmd.includes('Antigravity') || p.cmd.includes('antigravity')) &&
+          !p.cmd.includes('manager')
+        );
       }
     });
 

--- a/src/ipc/tray/handler.ts
+++ b/src/ipc/tray/handler.ts
@@ -41,7 +41,11 @@ export function initTray(mainWindow: BrowserWindow) {
 
   // PATCH 3: Destroy existing tray before creating new one (prevents zombie tray icons)
   if (tray) {
-    tray.destroy();
+    try {
+      tray.destroy();
+    } catch (e) {
+      logger.error('Failed to destroy existing tray', e);
+    }
     tray = null;
     logger.info('Destroyed existing tray before creating new one');
   }
@@ -52,6 +56,13 @@ export function initTray(mainWindow: BrowserWindow) {
     : path.join(process.resourcesPath, 'assets/tray.png');
 
   const icon = nativeImage.createFromPath(iconPath);
+
+  // Verify icon is valid before creating tray
+  if (icon.isEmpty()) {
+    logger.error(`Tray icon not found or invalid at path: ${iconPath}`);
+    return;
+  }
+
   tray = new Tray(icon);
   tray.setToolTip('Antigravity Manager');
 
@@ -169,7 +180,11 @@ export function setTrayLanguage(lang: string) {
 
 export function destroyTray() {
   if (tray) {
-    tray.destroy();
+    try {
+      tray.destroy();
+    } catch (e) {
+      logger.error('Failed to destroy tray', e);
+    }
     tray = null;
     logger.info('Tray destroyed');
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,7 +156,11 @@ app.on('before-quit', () => {
 
 app.on('will-quit', (event) => {
   logger.info('App will quit event triggered');
-  destroyTray();
+  try {
+    destroyTray();
+  } catch (err) {
+    logger.error('Failed to destroy tray during will-quit', err);
+  }
 });
 
 app.on('quit', (event, exitCode) => {


### PR DESCRIPTION
## Summary
- Fixes "Quit Application" not working from tray menu on Linux
- Fixes zombie tray icons appearing after minimize/restore
- Fixes case-sensitive process detection on Linux
- Fixes self-kill when closing Antigravity IDE

## Changes
1. **before-quit handler**: Set `isQuitting = true` before quit to allow window close
2. **Case-insensitive pgrep**: `pgrep -xi` instead of `pgrep -x` for Linux compatibility
3. **Self-kill prevention**: Added `antigravity-manager` to exclusion filter
4. **Tray cleanup**: Destroy existing tray in `initTray()` and `will-quit` handler

## Test plan
- [ ] Start AntigravityManager
- [ ] Click tray icon → Quit Application → app should exit and tray icon disappear
- [ ] Minimize/restore multiple times → should always have only one tray icon
- [ ] Close Antigravity IDE via Manager → Manager should not kill itself

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)