### PR TITLE
fix: refresh Google token before account switch injection

### DIFF
--- a/src/ipc/cloud/handler.ts
+++ b/src/ipc/cloud/handler.ts
@@ -503,38 +503,43 @@ export async function switchCloudAccount(accountId: string): Promise<void> {
         account.device_profile = generated;
       }
 
-      // 1. Prepare token refresh promise (start it in parallel with process exit)
       const tokenRefreshPromise = (async () => {
         const now = Math.floor(Date.now() / 1000);
-        if (account.token.expiry_timestamp < now + 1200) {
-          logger.info(`Token for ${account.email} near expiry, refreshing in parallel...`);
-          try {
-            const newTokenData = await GoogleAPIService.refreshAccessToken(
-              account.token.refresh_token,
-              account.proxy_url,
-              account.token.oauth_client_key,
-            );
+        if (!isString(account.token.refresh_token) || isEmpty(account.token.refresh_token.trim())) {
+          logger.warn(
+            `Token for ${account.email} has no refresh token; switched IDE session may expire without recovery.`,
+          );
+          return;
+        }
 
-            const updatedToken = {
-              ...account.token,
-              access_token: newTokenData.access_token,
-              expires_in: newTokenData.expires_in,
-              expiry_timestamp: now + newTokenData.expires_in,
-              oauth_client_key: GoogleAPIService.normalizeRefreshedOAuthClientKey(
-                account.token,
-                newTokenData.oauth_client_key,
-              ),
-            };
-            await CloudAccountRepo.updateToken(account.id, updatedToken);
+        logger.info(`Refreshing token for ${account.email} before IDE injection...`);
+        try {
+          const newTokenData = await GoogleAPIService.refreshAccessToken(
+            account.token.refresh_token,
+            account.proxy_url,
+            account.token.oauth_client_key,
+          );
 
-            account.token = updatedToken;
-            logger.info(`Token refreshed for ${account.email}`);
-          } catch (e) {
-            logger.warn('Failed to refresh token in parallel', e);
-            await markAccountStatusFromError(account, e);
-            const reason = extractErrorMessage(e);
-            throw new Error(formatSwitchRefreshError(reason));
-          }
+          const updatedToken = {
+            ...account.token,
+            access_token: newTokenData.access_token,
+            expires_in: newTokenData.expires_in,
+            expiry_timestamp: now + newTokenData.expires_in,
+            token_type: newTokenData.token_type,
+            oauth_client_key: GoogleAPIService.normalizeRefreshedOAuthClientKey(
+              account.token,
+              newTokenData.oauth_client_key,
+            ),
+          };
+          await CloudAccountRepo.updateToken(account.id, updatedToken);
+
+          account.token = updatedToken;
+          logger.info(`Token refreshed for ${account.email}`);
+        } catch (e) {
+          logger.warn('Failed to refresh token before IDE injection', e);
+          await markAccountStatusFromError(account, e);
+          const reason = extractErrorMessage(e);
+          throw new Error(formatSwitchRefreshError(reason));
         }
       })();
 

--- a/src/tests/unit/cloudHandler-sync.test.ts
+++ b/src/tests/unit/cloudHandler-sync.test.ts
@@ -509,6 +509,13 @@ describe('cloud switch fail-fast path', () => {
     const startAntigravityMock = vi.fn(async () => undefined);
     const recordSwitchFailureMock = vi.fn();
     const recordSwitchSuccessMock = vi.fn();
+    const updateTokenMock = vi.fn(async () => undefined);
+    const refreshAccessTokenMock = vi.fn(async () => ({
+      access_token: 'refreshed-access',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      oauth_client_key: 'custom_a',
+    }));
 
     const account = {
       id: 'acc-1',
@@ -537,7 +544,7 @@ describe('cloud switch fail-fast path', () => {
       CloudAccountRepo: {
         getAccount: vi.fn(async () => account),
         setDeviceBinding: vi.fn(),
-        updateToken: vi.fn(async () => undefined),
+        updateToken: updateTokenMock,
         injectCloudToken: vi.fn(() => {
           throw new Error('inject_failed');
         }),
@@ -590,7 +597,10 @@ describe('cloud switch fail-fast path', () => {
 
     vi.doMock('../../services/GoogleAPIService', () => ({
       GoogleAPIService: {
-        refreshAccessToken: vi.fn(async () => undefined),
+        refreshAccessToken: refreshAccessTokenMock,
+        normalizeRefreshedOAuthClientKey: vi.fn(
+          (_currentToken: unknown, refreshedClientKey?: string) => refreshedClientKey,
+        ),
       },
     }));
 
@@ -603,6 +613,14 @@ describe('cloud switch fail-fast path', () => {
     const { switchCloudAccount } = await import('../../ipc/cloud/handler');
     await expect(switchCloudAccount('acc-1')).rejects.toThrow('Switch failed: inject_failed');
 
+    expect(refreshAccessTokenMock).toHaveBeenCalledWith('refresh', undefined, undefined);
+    expect(updateTokenMock).toHaveBeenCalledWith(
+      'acc-1',
+      expect.objectContaining({
+        access_token: 'refreshed-access',
+        expiry_timestamp: expect.any(Number),
+      }),
+    );
     expect(applyDeviceProfileMock).toHaveBeenCalledTimes(1);
     expect(applyDeviceProfileMock).toHaveBeenCalledWith(account.device_profile);
     expect(startAntigravityMock).not.toHaveBeenCalled();


### PR DESCRIPTION
Body:
## Summary
- Refresh Google OAuth access tokens immediately before injecting a switched account into Antigravity IDE state.
- Persist refreshed token metadata before database injection.
- Extend switch-path test coverage for pre-injection token refresh.


Closes #163
