### PR TITLE
feat: update Antigravity Manager to support Antigravity IDE (2.0)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/toaster';
 import { LOCAL_STORAGE_KEYS } from '@/constants';
+import { useAppConfig } from '@/hooks/useAppConfig';
+import { EditionSelectionDialog } from '@/components/EditionSelectionDialog';
+import type { IdeEdition } from '@/types/config';
 
-function App() {
+function AppContent() {
   const { i18n } = useTranslation();
+  const { config, isLoading, saveConfig } = useAppConfig();
 
   useEffect(() => {
     syncWithLocalTheme();
@@ -22,7 +26,24 @@ function App() {
     }
   }, [i18n]);
 
-  return <RouterProvider router={router} />;
+  const handleEditionSelect = async (edition: IdeEdition) => {
+    if (config) {
+      await saveConfig({ ...config, ideEdition: edition });
+    }
+  };
+
+  const showEditionDialog = !isLoading && !!config && !config.ideEdition;
+
+  return (
+    <>
+      <RouterProvider router={router} />
+      <EditionSelectionDialog open={showEditionDialog} onSelect={handleEditionSelect} />
+    </>
+  );
+}
+
+function App() {
+  return <AppContent />;
 }
 
 const queryClient = new QueryClient();

--- a/src/components/EditionSelectionDialog.tsx
+++ b/src/components/EditionSelectionDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { IdeEdition } from '@/types/config';
+import { cn } from '@/lib/utils';
+
+interface EditionSelectionDialogProps {
+  open: boolean;
+  onSelect: (edition: IdeEdition) => void;
+}
+
+export function EditionSelectionDialog({ open, onSelect }: EditionSelectionDialogProps) {
+  const { t } = useTranslation();
+  const [selectedEdition, setSelectedEdition] = useState<IdeEdition | null>(null);
+
+  const handleConfirm = () => {
+    if (selectedEdition) {
+      onSelect(selectedEdition);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent className="sm:max-w-xl" onInteractOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>{t('editionSelection.title')}</DialogTitle>
+          <DialogDescription>{t('editionSelection.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <Card
+            className={cn(
+              'cursor-pointer transition-all hover:border-primary',
+              selectedEdition === '1.x' && 'border-primary ring-2 ring-primary/20',
+            )}
+            onClick={() => setSelectedEdition('1.x')}
+          >
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                  1
+                </span>
+                {t('editionSelection.edition1x.name')}
+              </CardTitle>
+              <CardDescription>{t('editionSelection.edition1x.description')}</CardDescription>
+            </CardHeader>
+          </Card>
+
+          <Card
+            className={cn(
+              'cursor-pointer transition-all hover:border-primary',
+              selectedEdition === '2.0' && 'border-primary ring-2 ring-primary/20',
+            )}
+            onClick={() => setSelectedEdition('2.0')}
+          >
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-purple-100 text-sm font-bold text-purple-700 dark:bg-purple-900 dark:text-purple-300">
+                  2
+                </span>
+                {t('editionSelection.edition20.name')}
+              </CardTitle>
+              <CardDescription>{t('editionSelection.edition20.description')}</CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleConfirm} disabled={!selectedEdition}>
+            {t('editionSelection.confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -2,12 +2,12 @@ import { app } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import path from 'path';
 import fs from 'fs';
-import { getAppDataDir } from './utils/paths';
+import { getAgentDir } from './utils/paths';
 import { logger } from './utils/logger';
 
 function getQuickConfig() {
   try {
-    const configPath = path.join(getAppDataDir(), 'gui_config.json');
+    const configPath = path.join(getAgentDir(), 'gui_config.json');
     if (fs.existsSync(configPath)) {
       const content = fs.readFileSync(configPath, 'utf-8');
       const config = JSON.parse(content);

--- a/src/ipc/account/handler.ts
+++ b/src/ipc/account/handler.ts
@@ -28,6 +28,7 @@ import {
 import { runWithSwitchGuard } from '../switchGuard';
 import { executeSwitchFlow } from '../switchFlow';
 import { shell } from 'electron';
+import { ConfigManager } from '../config/manager';
 
 type AccountIndex = Record<string, Account>;
 const SWITCH_EXIT_TIMEOUT_MS = 10000;
@@ -251,6 +252,7 @@ export async function switchAccount(accountId: string): Promise<void> {
       targetProfile: account.deviceProfile || null,
       applyFingerprint: isIdentityProfileApplyEnabled(),
       processExitTimeoutMs: SWITCH_EXIT_TIMEOUT_MS,
+      edition: ConfigManager.getCachedConfig()?.ideEdition || undefined,
       performSwitch: async () => {
         // NOTE Load backup file
         const backupContent = fs.readFileSync(backupPath, 'utf-8');

--- a/src/ipc/account/handler.ts
+++ b/src/ipc/account/handler.ts
@@ -253,13 +253,13 @@ export async function switchAccount(accountId: string): Promise<void> {
       applyFingerprint: isIdentityProfileApplyEnabled(),
       processExitTimeoutMs: SWITCH_EXIT_TIMEOUT_MS,
       edition: ConfigManager.getCachedConfig()?.ideEdition || undefined,
-      performSwitch: async () => {
+      performSwitch: async (edition) => {
         // NOTE Load backup file
         const backupContent = fs.readFileSync(backupPath, 'utf-8');
         const backupData: AccountBackupData = JSON.parse(backupContent);
 
         // NOTE Restore data to DB
-        dbRestore(backupData);
+        dbRestore(backupData, edition);
 
         // NOTE Update last used
         account.last_used = new Date().toISOString();

--- a/src/ipc/cloud/handler.ts
+++ b/src/ipc/cloud/handler.ts
@@ -21,7 +21,7 @@ import {
   readCurrentDeviceProfile,
   saveGlobalOriginalProfile,
 } from '../../ipc/device/handler';
-import { getAntigravityDbPaths } from '../../utils/paths';
+import { getAntigravityDbPaths, getAntigravityDbPathsForEdition } from '../../utils/paths';
 import { runWithSwitchGuard } from '../../ipc/switchGuard';
 import { executeSwitchFlow } from '../../ipc/switchFlow';
 import type { DeviceProfile, DeviceProfilesSnapshot } from '../../types/account';
@@ -552,9 +552,11 @@ export async function switchCloudAccount(accountId: string): Promise<void> {
         applyFingerprint: isIdentityProfileApplyEnabled(),
         processExitTimeoutMs: 10000,
         edition: ConfigManager.getCachedConfig()?.ideEdition || undefined,
-        performSwitch: async () => {
+        performSwitch: async (edition) => {
           // 3. Backup Database (Optimized to avoid race conditions)
-          const dbPaths = getAntigravityDbPaths();
+          const dbPaths = edition
+            ? getAntigravityDbPathsForEdition(edition)
+            : getAntigravityDbPaths();
           for (const dbPath of dbPaths) {
             try {
               const backupPath = `${dbPath}.backup`;
@@ -569,7 +571,7 @@ export async function switchCloudAccount(accountId: string): Promise<void> {
           }
 
           // 4. Inject Token
-          CloudAccountRepo.injectCloudToken(account);
+          CloudAccountRepo.injectCloudToken(account, edition);
 
           // 5. Update usage and active status
           CloudAccountRepo.updateLastUsed(account.id);

--- a/src/ipc/cloud/handler.ts
+++ b/src/ipc/cloud/handler.ts
@@ -26,6 +26,7 @@ import { runWithSwitchGuard } from '../../ipc/switchGuard';
 import { executeSwitchFlow } from '../../ipc/switchFlow';
 import type { DeviceProfile, DeviceProfilesSnapshot } from '../../types/account';
 import { classifyAccountStatusFromError, extractErrorMessage } from '../../utils/account-status';
+import { ConfigManager } from '../../ipc/config/manager';
 
 // Helper to update tray
 function notifyTrayUpdate(account: CloudAccount) {
@@ -550,6 +551,7 @@ export async function switchCloudAccount(accountId: string): Promise<void> {
         targetProfile: account.device_profile || null,
         applyFingerprint: isIdentityProfileApplyEnabled(),
         processExitTimeoutMs: 10000,
+        edition: ConfigManager.getCachedConfig()?.ideEdition || undefined,
         performSwitch: async () => {
           // 3. Backup Database (Optimized to avoid race conditions)
           const dbPaths = getAntigravityDbPaths();
@@ -839,7 +841,7 @@ export async function importCloudAccounts(
         result.imported++;
       }
     } catch (error: any) {
-      result.errors.push(`Failed to import ${acc.email}: ${error.message}`);
+      result.errors.push(`Failed to import ${importedAccount.email}: ${error.message}`);
     }
   }
 

--- a/src/ipc/cloud/router.ts
+++ b/src/ipc/cloud/router.ts
@@ -25,12 +25,18 @@ import {
   importCloudAccounts,
 } from './handler';
 import { CloudAccountRepo } from '../database/cloudHandler';
+import { ConfigManager } from '../config/manager';
 import { CloudAccountSchema } from '../../types/cloudAccount';
 import { DeviceProfileSchema, DeviceProfilesSnapshotSchema } from '../../types/account';
 import { logger } from '../../utils/logger';
 import { getSwitchMetricsSnapshot } from '../switchMetrics';
 import { getSwitchGuardSnapshot } from '../switchGuard';
 import { getDeviceHardeningSnapshot } from '../device/handler';
+
+function getEdition() {
+  const config = ConfigManager.getCachedConfig() || ConfigManager.loadConfig();
+  return config.ideEdition || undefined;
+}
 
 const switchOwnerSchema = z.enum(['local-account-switch', 'cloud-account-switch']);
 const switchMetricBucketSchema = z.object({
@@ -200,7 +206,7 @@ export const cloudRouter = os.router({
 
   syncLocalAccount: os.output(CloudAccountSchema.nullable()).handler(async () => {
     try {
-      const result = await CloudAccountRepo.syncFromIDE();
+      const result = await CloudAccountRepo.syncFromIDE(getEdition());
 
       return result;
     } catch (error: any) {

--- a/src/ipc/config/manager.ts
+++ b/src/ipc/config/manager.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { AppConfig, DEFAULT_APP_CONFIG } from '../../types/config';
-import { getAppDataDir } from '../../utils/paths';
+import { getAgentDir } from '../../utils/paths';
 import { logger } from '../../utils/logger';
 
 const CONFIG_FILENAME = 'gui_config.json';
@@ -11,11 +11,11 @@ export class ConfigManager {
   private static saveQueue: Promise<void> = Promise.resolve();
 
   private static getConfigPath(): string {
-    const appDataDir = getAppDataDir();
-    if (!fs.existsSync(appDataDir)) {
-      fs.mkdirSync(appDataDir, { recursive: true });
+    const managerDataDir = getAgentDir();
+    if (!fs.existsSync(managerDataDir)) {
+      fs.mkdirSync(managerDataDir, { recursive: true });
     }
-    return path.join(appDataDir, CONFIG_FILENAME);
+    return path.join(managerDataDir, CONFIG_FILENAME);
   }
 
   static loadConfig(): AppConfig {

--- a/src/ipc/database/cloudHandler.ts
+++ b/src/ipc/database/cloudHandler.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { desc, eq } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { isNumber, isObjectLike, isPlainObject, isString } from 'lodash-es';
-import { getCloudAccountsDbPath, getAntigravityDbPaths } from '../../utils/paths';
+import { getCloudAccountsDbPath, getAntigravityDbPaths, getAntigravityDbPathsForEdition } from '../../utils/paths';
 import { logger } from '../../utils/logger';
 import {
   CloudAccount,
@@ -23,6 +23,7 @@ import { parseRow, parseRows } from '../../utils/sqlite';
 import { configureDatabase, openDrizzleConnection } from './dbConnection';
 import { accounts, itemTable, settings } from './schema';
 import * as drizzleSchema from './schema';
+import type { IdeEdition } from '../../types/config';
 
 const SQLITE_BUSY_CODES = new Set(['SQLITE_BUSY', 'SQLITE_LOCKED']);
 const SQLITE_BUSY_TIMEOUT_MS = 3000;
@@ -1260,8 +1261,10 @@ export class CloudAccountRepo {
     throw lastError;
   }
 
-  static injectCloudToken(account: CloudAccount): void {
-    const dbPaths = getAntigravityDbPaths();
+  static injectCloudToken(account: CloudAccount, edition?: IdeEdition): void {
+    const dbPaths = edition
+      ? getAntigravityDbPathsForEdition(edition)
+      : getAntigravityDbPaths();
     const dbPath = dbPaths.find((p) => fs.existsSync(p)) ?? null;
 
     if (!dbPath) {
@@ -1429,9 +1432,11 @@ export class CloudAccountRepo {
     }
   }
 
-  static async syncFromIDE(): Promise<CloudAccount | null> {
+  static async syncFromIDE(edition?: IdeEdition): Promise<CloudAccount | null> {
     // Try all possible database paths
-    const dbPaths = getAntigravityDbPaths();
+    const dbPaths = edition
+      ? getAntigravityDbPathsForEdition(edition)
+      : getAntigravityDbPaths();
     logger.info(`SyncLocal: Checking database paths: ${JSON.stringify(dbPaths)}`);
 
     const dbPath =

--- a/src/ipc/database/handler.ts
+++ b/src/ipc/database/handler.ts
@@ -130,11 +130,11 @@ function readItemValue(
  * Gets the current account info.
  * @returns {AccountInfo} The current account info.
  */
-export function getCurrentAccountInfo(): AccountInfo {
+export function getCurrentAccountInfo(edition?: IdeEdition): AccountInfo {
   // NOTE Database existence is now handled by getDatabaseConnection
   let connection: ReturnType<typeof openDrizzleConnection> | null = null;
   try {
-    connection = getDatabaseConnection();
+    connection = getDatabaseConnection(undefined, edition);
     const { orm } = connection;
 
     // Query for auth status
@@ -232,10 +232,13 @@ export function getCurrentAccountInfo(): AccountInfo {
   }
 }
 
-export function backupAccount(account: AccountBackupData['account']): AccountBackupData {
+export function backupAccount(
+  account: AccountBackupData['account'],
+  edition?: IdeEdition,
+): AccountBackupData {
   let connection: ReturnType<typeof openDrizzleConnection> | null = null;
   try {
-    connection = getDatabaseConnection();
+    connection = getDatabaseConnection(undefined, edition);
     const { orm } = connection;
 
     // NOTE Backup only specific keys
@@ -279,8 +282,10 @@ export function backupAccount(account: AccountBackupData['account']): AccountBac
  * @param backup {AccountBackupData} The backup data to restore.
  * @throws {Error} If the backup data cannot be restored.
  */
-export function restoreAccount(backup: AccountBackupData): void {
-  const dbPaths = getAntigravityDbPaths();
+export function restoreAccount(backup: AccountBackupData, edition?: IdeEdition): void {
+  const dbPaths = edition
+    ? getAntigravityDbPathsForEdition(edition)
+    : getAntigravityDbPaths();
   if (dbPaths.length === 0) {
     throw new Error('No Antigravity database paths found');
   }

--- a/src/ipc/database/handler.ts
+++ b/src/ipc/database/handler.ts
@@ -6,10 +6,11 @@ import { isString } from 'lodash-es';
 import { AccountBackupData, AccountInfo } from '../../types/account';
 import { ItemTableValueRowSchema, type ItemTableKey } from '../../types/db';
 import { logger } from '../../utils/logger';
-import { getAntigravityDbPaths } from '../../utils/paths';
+import { getAntigravityDbPaths, getAntigravityDbPathsForEdition } from '../../utils/paths';
 import { parseRow } from '../../utils/sqlite';
 import { openDrizzleConnection } from './dbConnection';
 import { itemTable } from './schema';
+import type { IdeEdition } from '../../types/config';
 
 const KEYS_TO_BACKUP: ItemTableKey[] = [
   'antigravityAuthStatus',
@@ -29,14 +30,16 @@ function openIdeDb(dbPath: string, readOnly = false): ReturnType<typeof openDriz
  * Initializes the database and ensures WAL mode is enabled.
  * Should be called on application startup.
  */
-export function initDatabase(): void {
+export function initDatabase(edition?: IdeEdition): void {
   try {
-    const dbPaths = getAntigravityDbPaths();
+    const dbPaths = edition
+      ? getAntigravityDbPathsForEdition(edition)
+      : getAntigravityDbPaths();
     if (dbPaths.length === 0) {
       return;
     }
 
-    const { raw } = getDatabaseConnection();
+    const { raw } = getDatabaseConnection(undefined, edition);
     raw.close();
     logger.info('Database initialized and verified (WAL mode)');
   } catch (error) {
@@ -83,10 +86,14 @@ function ensureDatabaseExists(dbPath: string): void {
 /**
  * Gets a database connection.
  * @param dbPath {string} The path to the database file.
+ * @param edition {IdeEdition} The IDE edition to use for path resolution.
  * @returns {ReturnType<typeof openDrizzleConnection>} The database connection.
  */
-export function getDatabaseConnection(dbPath?: string): ReturnType<typeof openDrizzleConnection> {
-  const targetPath = dbPath || getAntigravityDbPaths()[0];
+export function getDatabaseConnection(
+  dbPath?: string,
+  edition?: IdeEdition,
+): ReturnType<typeof openDrizzleConnection> {
+  const targetPath = dbPath || (edition ? getAntigravityDbPathsForEdition(edition) : getAntigravityDbPaths())[0];
 
   if (!targetPath) {
     throw new Error('No Antigravity database path found');

--- a/src/ipc/database/router.ts
+++ b/src/ipc/database/router.ts
@@ -2,23 +2,29 @@ import { z } from 'zod';
 import { os } from '@orpc/server';
 import { backupAccount, restoreAccount, getCurrentAccountInfo } from './handler';
 import { AccountBackupDataSchema, AccountInfoSchema, AccountSchema } from '../../types/account';
+import { ConfigManager } from '../config/manager';
+
+function getEdition() {
+  const config = ConfigManager.getCachedConfig() || ConfigManager.loadConfig();
+  return config.ideEdition || undefined;
+}
 
 export const databaseRouter = os.router({
   backupAccount: os
     .input(AccountSchema)
     .output(AccountBackupDataSchema)
     .handler(async ({ input }) => {
-      return backupAccount(input);
+      return backupAccount(input, getEdition());
     }),
 
   restoreAccount: os
     .input(AccountBackupDataSchema)
     .output(z.void())
     .handler(async ({ input }) => {
-      restoreAccount(input);
+      restoreAccount(input, getEdition());
     }),
 
   getCurrentAccountInfo: os.output(AccountInfoSchema).handler(async () => {
-    return getCurrentAccountInfo();
+    return getCurrentAccountInfo(getEdition());
   }),
 });

--- a/src/ipc/process/handler.ts
+++ b/src/ipc/process/handler.ts
@@ -61,7 +61,7 @@ function isPgrepNoMatchError(error: unknown): boolean {
   }
 
   const message = error.message.toLowerCase();
-  const hasPgrep = message.includes('pgrep') && (message.includes('antigravity') || message.includes('antigravity ide'));
+  const hasPgrep = message.includes('pgrep') && message.includes('antigravity');
   const code = (error as { code?: number }).code;
   return hasPgrep && code === 1;
 }
@@ -76,9 +76,9 @@ export async function isProcessRunning(): Promise<boolean> {
     const platform = process.platform;
     const currentPid = process.pid;
 
-    // Use find-process to search for Antigravity IDE processes
+    // Use find-process to search for Antigravity processes
     const allMatches: ProcessInfo[] = [];
-    const searchNames = ['Antigravity IDE', 'antigravity-ide', 'Antigravity', 'antigravity'];
+    const searchNames = ['Antigravity', 'antigravity'];
     if (platform === 'linux') {
       searchNames.push('electron');
     }
@@ -109,7 +109,7 @@ export async function isProcessRunning(): Promise<boolean> {
       logger.debug('No Antigravity process found (pgrep returned 1)');
     }
 
-    logger.debug(`Found ${processes.length} processes matching 'Antigravity IDE/antigravity-ide'`);
+    logger.debug(`Found ${processes.length} processes matching 'Antigravity/antigravity'`);
 
     for (const proc of processes) {
       // Skip self
@@ -135,22 +135,22 @@ export async function isProcessRunning(): Promise<boolean> {
       }
 
       if (platform === 'darwin') {
-        // macOS: Check for Antigravity IDE.app in path
-        if (cmd.includes('antigravity ide.app') || cmd.includes('antigravity-ide.app')) {
+        // macOS: Check for Antigravity.app in path
+        if (cmd.includes('antigravity.app')) {
           logger.debug(
-            `Found Antigravity IDE process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+            `Found Antigravity process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
           );
           return true;
         }
-        // Also check if the process name is exactly 'Antigravity IDE' (main process)
-        if ((name === 'antigravity ide' || name === 'antigravity-ide') && !isHelperProcess(name, cmd)) {
-          logger.debug(`Found Antigravity IDE process: PID=${proc.pid}, name=${name}`);
+        // Also check if the process name is exactly 'Antigravity' (main process)
+        if (name === 'antigravity' && !isHelperProcess(name, cmd)) {
+          logger.debug(`Found Antigravity process: PID=${proc.pid}, name=${name}`);
           return true;
         }
       } else if (platform === 'win32') {
-        // Windows: Check for Antigravity IDE.exe
-        if (name === 'antigravity ide.exe' || name === 'antigravity-ide.exe' || name === 'antigravity ide' || name === 'antigravity-ide') {
-          logger.debug(`Found Antigravity IDE process: PID=${proc.pid}, name=${name}`);
+        // Windows: Check for Antigravity.exe
+        if (name === 'antigravity.exe' || name === 'antigravity') {
+          logger.debug(`Found Antigravity process: PID=${proc.pid}, name=${name}`);
           return true;
         }
       } else {
@@ -159,31 +159,28 @@ export async function isProcessRunning(): Promise<boolean> {
 
         if (nameLower === 'electron') {
           // Stricter check for AUR/Electron wrapper:
-          // Must include antigravity-ide in command line but NOT manager or tools
+          // Must include antigravity in command line but NOT manager or tools
           const isAntigravityApp =
-            (cmdLower.includes('/antigravity-ide') ||
-              cmdLower.includes(' antigravity-ide') ||
-              cmdLower.endsWith('antigravity-ide') ||
-              cmdLower.includes('/antigravity ide') ||
-              cmdLower.includes(' antigravity ide') ||
-              cmdLower.endsWith('antigravity ide')) &&
+            (cmdLower.includes('/antigravity') ||
+              cmdLower.includes(' antigravity') ||
+              cmdLower.endsWith('antigravity')) &&
             !cmdLower.includes('manager') &&
             !cmdLower.includes('tools');
 
           if (isAntigravityApp) {
             logger.debug(
-              `Found Antigravity IDE (AUR/electron) process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+              `Found Antigravity (AUR/electron) process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
             );
             return true;
           }
         }
 
         if (
-          (name.includes('antigravity-ide') || name.includes('antigravity ide') || cmd.includes('/antigravity-ide') || cmd.includes('/antigravity ide')) &&
+          (name.includes('antigravity') || cmd.includes('/antigravity')) &&
           !name.includes('tools')
         ) {
           logger.debug(
-            `Found Antigravity IDE process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+            `Found Antigravity process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
           );
           return true;
         }
@@ -202,7 +199,7 @@ export async function isProcessRunning(): Promise<boolean> {
  * @returns {boolean} True if the Antigravity process is running, false otherwise.
  */
 export async function closeAntigravity(): Promise<void> {
-  logger.info('Closing Antigravity IDE...');
+  logger.info('Closing Antigravity...');
   const platform = process.platform;
 
   try {
@@ -211,7 +208,7 @@ export async function closeAntigravity(): Promise<void> {
       // macOS: Use AppleScript to quit gracefully
       try {
         logger.info('Attempting graceful exit via AppleScript...');
-        execSync('osascript -e \'tell application "Antigravity IDE" to quit\'', {
+        execSync('osascript -e \'tell application "Antigravity" to quit\'', {
           stdio: 'ignore',
           timeout: 3000,
         });
@@ -226,7 +223,7 @@ export async function closeAntigravity(): Promise<void> {
         logger.info('Attempting graceful exit via taskkill...');
         // /T = Tree (child processes), /IM = Image Name
         // We do not wait long here.
-        execSync('taskkill /IM "Antigravity IDE.exe" /T', {
+        execSync('taskkill /IM "Antigravity.exe" /T', {
           stdio: 'ignore',
           timeout: 2000,
         });
@@ -246,7 +243,7 @@ export async function closeAntigravity(): Promise<void> {
         let output = '';
         if (platform === 'win32') {
           const psCommand = (cmdlet: string) =>
-            `powershell -NoProfile -Command "${cmdlet} Win32_Process -Filter \\"Name like 'Antigravity IDE%' OR Name like 'Antigravity%'\\" | Select-Object ProcessId, Name, CommandLine | ConvertTo-Csv -NoTypeInformation"`;
+            `powershell -NoProfile -Command "${cmdlet} Win32_Process -Filter \\"Name like 'Antigravity%'\\" | Select-Object ProcessId, Name, CommandLine | ConvertTo-Csv -NoTypeInformation"`;
 
           try {
             output = execSync(psCommand('Get-CimInstance'), {
@@ -299,18 +296,18 @@ export async function closeAntigravity(): Promise<void> {
             }
           }
         } else {
-            const lines = output.split('\n');
-            for (const line of lines) {
-              const parts = line.trim().split(/\s+/);
-              if (parts.length < 2) continue;
+          const lines = output.split('\n');
+          for (const line of lines) {
+            const parts = line.trim().split(/\s+/);
+            if (parts.length < 2) continue;
 
-              const pid = parseInt(parts[0]);
-              if (isNaN(pid)) continue;
-              const rest = parts.slice(1).join(' ');
-              if (rest.includes('Antigravity IDE') || rest.includes('antigravity-ide') || rest.includes('Antigravity') || rest.includes('antigravity')) {
-                processList.push({ pid, name: parts[1], cmd: rest });
-              }
+            const pid = parseInt(parts[0]);
+            if (isNaN(pid)) continue;
+            const rest = parts.slice(1).join(' ');
+            if (rest.includes('Antigravity') || rest.includes('antigravity')) {
+              processList.push({ pid, name: parts[1], cmd: rest });
             }
+          }
         }
         return processList;
       } catch (e) {
@@ -328,28 +325,27 @@ export async function closeAntigravity(): Promise<void> {
       if (p.cmd.includes('Antigravity Manager') || p.cmd.includes('antigravity-manager')) {
         return false;
       }
-      // Match Antigravity IDE (but not manager)
+      // Match Antigravity (but not manager)
       if (platform === 'win32') {
         return (
-          p.cmd.includes('Antigravity IDE.exe') ||
           p.cmd.includes('Antigravity.exe') ||
           (p.cmd.includes('antigravity') && !p.cmd.includes('manager'))
         );
       } else {
         // Explicit !manager check for Linux/macOS to be defensive
         return (
-          (p.cmd.includes('Antigravity IDE') || p.cmd.includes('antigravity-ide') || p.cmd.includes('Antigravity') || p.cmd.includes('antigravity')) &&
+          (p.cmd.includes('Antigravity') || p.cmd.includes('antigravity')) &&
           !p.cmd.includes('manager')
         );
       }
     });
 
     if (targetProcessList.length === 0) {
-      logger.info('No Antigravity IDE processes found running.');
+      logger.info('No Antigravity processes found running.');
       return;
     }
 
-    logger.info(`Found ${targetProcessList.length} remaining Antigravity IDE processes. Killing...`);
+    logger.info(`Found ${targetProcessList.length} remaining Antigravity processes. Killing...`);
 
     for (const p of targetProcessList) {
       try {
@@ -363,9 +359,9 @@ export async function closeAntigravity(): Promise<void> {
     // Fallback to simple kill if everything fails
     try {
       if (platform === 'win32') {
-        execSync('taskkill /F /IM "Antigravity IDE.exe" /T', { stdio: 'ignore' });
+        execSync('taskkill /F /IM "Antigravity.exe" /T', { stdio: 'ignore' });
       } else {
-        execSync('pkill -9 -f "Antigravity IDE"', { stdio: 'ignore' });
+        execSync('pkill -9 -f Antigravity', { stdio: 'ignore' });
       }
     } catch {
       // Ignore
@@ -389,7 +385,7 @@ export async function _waitForProcessExit(
     }
     await new Promise((resolve) => setTimeout(resolve, pollInterval));
   }
-  throw new Error(`Antigravity IDE process did not exit within ${timeoutMs}ms`);
+  throw new Error(`Antigravity process did not exit within ${timeoutMs}ms`);
 }
 
 /**
@@ -447,13 +443,13 @@ function shouldUseLinuxGpuSafeLaunchArgs(): boolean {
 
 async function startAntigravityByExecutable(execPath: string): Promise<void> {
   if (process.platform === 'darwin') {
-    await execAsync(`open -a "Antigravity IDE"`);
+    await execAsync(`open -a Antigravity`);
     return;
   }
 
   if (process.platform === 'win32') {
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity IDE executable path');
+      throw new Error('Unable to locate Antigravity executable path');
     }
     // Use start command to detach
     await execAsync(`start "" "${execPath}"`);
@@ -462,7 +458,7 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
 
   if (isWsl()) {
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity IDE executable path');
+      throw new Error('Unable to locate Antigravity executable path');
     }
     // In WSL, convert path and use cmd.exe
     const winPath = execPath
@@ -474,7 +470,7 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
   }
 
   if (!execPath) {
-    throw new Error('Unable to locate Antigravity IDE executable path');
+    throw new Error('Unable to locate Antigravity executable path');
   }
 
   const launchArgs = shouldUseLinuxGpuSafeLaunchArgs() ? [...LINUX_GPU_SAFE_LAUNCH_ARGS] : [];
@@ -495,31 +491,31 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
  * @returns {Promise<void>} A promise that resolves when the process starts.
  */
 export async function startAntigravity(useUri = true): Promise<void> {
-  logger.info('Starting Antigravity IDE...');
+  logger.info('Starting Antigravity...');
 
   if (await isProcessRunning()) {
-    logger.info('Antigravity IDE is already running');
+    logger.info('Antigravity is already running');
     return;
   }
 
   if (useUri) {
     logger.info('Using URI protocol to start...');
-    const uri = 'antigravity-ide://oauth-success';
+    const uri = 'antigravity://oauth-success';
 
     if (await openUri(uri)) {
-      logger.info('Antigravity IDE URI launch command sent');
+      logger.info('Antigravity URI launch command sent');
 
       if (process.platform !== 'linux' || isWsl()) {
         return;
       }
 
       if (await waitForAntigravityStartup()) {
-        logger.info('Antigravity IDE process detected after URI launch');
+        logger.info('Antigravity process detected after URI launch');
         return;
       }
 
       logger.warn(
-        'URI launch did not keep Antigravity IDE running on Linux. Falling back to executable launch.',
+        'URI launch did not keep Antigravity running on Linux. Falling back to executable launch.',
       );
     } else {
       logger.warn('URI launch failed, trying executable path...');
@@ -532,18 +528,18 @@ export async function startAntigravity(useUri = true): Promise<void> {
 
   try {
     await startAntigravityByExecutable(execPath);
-    logger.info('Antigravity IDE launch command sent');
+    logger.info('Antigravity launch command sent');
 
     if (process.platform === 'linux' && !isWsl()) {
       const started = await waitForAntigravityStartup();
       if (!started) {
         logger.warn(
-          'Antigravity IDE launch command completed, but process startup could not be confirmed on Linux.',
+          'Antigravity launch command completed, but process startup could not be confirmed on Linux.',
         );
       }
     }
   } catch (error) {
-    logger.error('Failed to start Antigravity IDE via executable', error);
+    logger.error('Failed to start Antigravity via executable', error);
     throw error;
   }
 }

--- a/src/ipc/process/handler.ts
+++ b/src/ipc/process/handler.ts
@@ -61,7 +61,7 @@ function isPgrepNoMatchError(error: unknown): boolean {
   }
 
   const message = error.message.toLowerCase();
-  const hasPgrep = message.includes('pgrep') && message.includes('antigravity');
+  const hasPgrep = message.includes('pgrep') && (message.includes('antigravity') || message.includes('antigravity ide'));
   const code = (error as { code?: number }).code;
   return hasPgrep && code === 1;
 }
@@ -76,9 +76,9 @@ export async function isProcessRunning(): Promise<boolean> {
     const platform = process.platform;
     const currentPid = process.pid;
 
-    // Use find-process to search for Antigravity processes
+    // Use find-process to search for Antigravity IDE processes
     const allMatches: ProcessInfo[] = [];
-    const searchNames = ['Antigravity', 'antigravity'];
+    const searchNames = ['Antigravity IDE', 'antigravity-ide', 'Antigravity', 'antigravity'];
     if (platform === 'linux') {
       searchNames.push('electron');
     }
@@ -109,7 +109,7 @@ export async function isProcessRunning(): Promise<boolean> {
       logger.debug('No Antigravity process found (pgrep returned 1)');
     }
 
-    logger.debug(`Found ${processes.length} processes matching 'Antigravity/antigravity'`);
+    logger.debug(`Found ${processes.length} processes matching 'Antigravity IDE/antigravity-ide'`);
 
     for (const proc of processes) {
       // Skip self
@@ -135,22 +135,22 @@ export async function isProcessRunning(): Promise<boolean> {
       }
 
       if (platform === 'darwin') {
-        // macOS: Check for Antigravity.app in path
-        if (cmd.includes('antigravity.app')) {
+        // macOS: Check for Antigravity IDE.app in path
+        if (cmd.includes('antigravity ide.app') || cmd.includes('antigravity-ide.app')) {
           logger.debug(
-            `Found Antigravity process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+            `Found Antigravity IDE process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
           );
           return true;
         }
-        // Also check if the process name is exactly 'Antigravity' (main process)
-        if (name === 'antigravity' && !isHelperProcess(name, cmd)) {
-          logger.debug(`Found Antigravity process: PID=${proc.pid}, name=${name}`);
+        // Also check if the process name is exactly 'Antigravity IDE' (main process)
+        if ((name === 'antigravity ide' || name === 'antigravity-ide') && !isHelperProcess(name, cmd)) {
+          logger.debug(`Found Antigravity IDE process: PID=${proc.pid}, name=${name}`);
           return true;
         }
       } else if (platform === 'win32') {
-        // Windows: Check for Antigravity.exe
-        if (name === 'antigravity.exe' || name === 'antigravity') {
-          logger.debug(`Found Antigravity process: PID=${proc.pid}, name=${name}`);
+        // Windows: Check for Antigravity IDE.exe
+        if (name === 'antigravity ide.exe' || name === 'antigravity-ide.exe' || name === 'antigravity ide' || name === 'antigravity-ide') {
+          logger.debug(`Found Antigravity IDE process: PID=${proc.pid}, name=${name}`);
           return true;
         }
       } else {
@@ -159,28 +159,31 @@ export async function isProcessRunning(): Promise<boolean> {
 
         if (nameLower === 'electron') {
           // Stricter check for AUR/Electron wrapper:
-          // Must include antigravity in command line but NOT manager or tools
+          // Must include antigravity-ide in command line but NOT manager or tools
           const isAntigravityApp =
-            (cmdLower.includes('/antigravity') ||
-              cmdLower.includes(' antigravity') ||
-              cmdLower.endsWith('antigravity')) &&
+            (cmdLower.includes('/antigravity-ide') ||
+              cmdLower.includes(' antigravity-ide') ||
+              cmdLower.endsWith('antigravity-ide') ||
+              cmdLower.includes('/antigravity ide') ||
+              cmdLower.includes(' antigravity ide') ||
+              cmdLower.endsWith('antigravity ide')) &&
             !cmdLower.includes('manager') &&
             !cmdLower.includes('tools');
 
           if (isAntigravityApp) {
             logger.debug(
-              `Found Antigravity (AUR/electron) process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+              `Found Antigravity IDE (AUR/electron) process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
             );
             return true;
           }
         }
 
         if (
-          (name.includes('antigravity') || cmd.includes('/antigravity')) &&
+          (name.includes('antigravity-ide') || name.includes('antigravity ide') || cmd.includes('/antigravity-ide') || cmd.includes('/antigravity ide')) &&
           !name.includes('tools')
         ) {
           logger.debug(
-            `Found Antigravity process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+            `Found Antigravity IDE process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
           );
           return true;
         }
@@ -199,7 +202,7 @@ export async function isProcessRunning(): Promise<boolean> {
  * @returns {boolean} True if the Antigravity process is running, false otherwise.
  */
 export async function closeAntigravity(): Promise<void> {
-  logger.info('Closing Antigravity...');
+  logger.info('Closing Antigravity IDE...');
   const platform = process.platform;
 
   try {
@@ -208,7 +211,7 @@ export async function closeAntigravity(): Promise<void> {
       // macOS: Use AppleScript to quit gracefully
       try {
         logger.info('Attempting graceful exit via AppleScript...');
-        execSync('osascript -e \'tell application "Antigravity" to quit\'', {
+        execSync('osascript -e \'tell application "Antigravity IDE" to quit\'', {
           stdio: 'ignore',
           timeout: 3000,
         });
@@ -223,7 +226,7 @@ export async function closeAntigravity(): Promise<void> {
         logger.info('Attempting graceful exit via taskkill...');
         // /T = Tree (child processes), /IM = Image Name
         // We do not wait long here.
-        execSync('taskkill /IM "Antigravity.exe" /T', {
+        execSync('taskkill /IM "Antigravity IDE.exe" /T', {
           stdio: 'ignore',
           timeout: 2000,
         });
@@ -243,7 +246,7 @@ export async function closeAntigravity(): Promise<void> {
         let output = '';
         if (platform === 'win32') {
           const psCommand = (cmdlet: string) =>
-            `powershell -NoProfile -Command "${cmdlet} Win32_Process -Filter \\"Name like 'Antigravity%'\\" | Select-Object ProcessId, Name, CommandLine | ConvertTo-Csv -NoTypeInformation"`;
+            `powershell -NoProfile -Command "${cmdlet} Win32_Process -Filter \\"Name like 'Antigravity IDE%' OR Name like 'Antigravity%'\\" | Select-Object ProcessId, Name, CommandLine | ConvertTo-Csv -NoTypeInformation"`;
 
           try {
             output = execSync(psCommand('Get-CimInstance'), {
@@ -296,18 +299,18 @@ export async function closeAntigravity(): Promise<void> {
             }
           }
         } else {
-          const lines = output.split('\n');
-          for (const line of lines) {
-            const parts = line.trim().split(/\s+/);
-            if (parts.length < 2) continue;
+            const lines = output.split('\n');
+            for (const line of lines) {
+              const parts = line.trim().split(/\s+/);
+              if (parts.length < 2) continue;
 
-            const pid = parseInt(parts[0]);
-            if (isNaN(pid)) continue;
-            const rest = parts.slice(1).join(' ');
-            if (rest.includes('Antigravity') || rest.includes('antigravity')) {
-              processList.push({ pid, name: parts[1], cmd: rest });
+              const pid = parseInt(parts[0]);
+              if (isNaN(pid)) continue;
+              const rest = parts.slice(1).join(' ');
+              if (rest.includes('Antigravity IDE') || rest.includes('antigravity-ide') || rest.includes('Antigravity') || rest.includes('antigravity')) {
+                processList.push({ pid, name: parts[1], cmd: rest });
+              }
             }
-          }
         }
         return processList;
       } catch (e) {
@@ -325,27 +328,28 @@ export async function closeAntigravity(): Promise<void> {
       if (p.cmd.includes('Antigravity Manager') || p.cmd.includes('antigravity-manager')) {
         return false;
       }
-      // Match Antigravity (but not manager)
+      // Match Antigravity IDE (but not manager)
       if (platform === 'win32') {
         return (
+          p.cmd.includes('Antigravity IDE.exe') ||
           p.cmd.includes('Antigravity.exe') ||
           (p.cmd.includes('antigravity') && !p.cmd.includes('manager'))
         );
       } else {
         // Explicit !manager check for Linux/macOS to be defensive
         return (
-          (p.cmd.includes('Antigravity') || p.cmd.includes('antigravity')) &&
+          (p.cmd.includes('Antigravity IDE') || p.cmd.includes('antigravity-ide') || p.cmd.includes('Antigravity') || p.cmd.includes('antigravity')) &&
           !p.cmd.includes('manager')
         );
       }
     });
 
     if (targetProcessList.length === 0) {
-      logger.info('No Antigravity processes found running.');
+      logger.info('No Antigravity IDE processes found running.');
       return;
     }
 
-    logger.info(`Found ${targetProcessList.length} remaining Antigravity processes. Killing...`);
+    logger.info(`Found ${targetProcessList.length} remaining Antigravity IDE processes. Killing...`);
 
     for (const p of targetProcessList) {
       try {
@@ -359,9 +363,9 @@ export async function closeAntigravity(): Promise<void> {
     // Fallback to simple kill if everything fails
     try {
       if (platform === 'win32') {
-        execSync('taskkill /F /IM "Antigravity.exe" /T', { stdio: 'ignore' });
+        execSync('taskkill /F /IM "Antigravity IDE.exe" /T', { stdio: 'ignore' });
       } else {
-        execSync('pkill -9 -f Antigravity', { stdio: 'ignore' });
+        execSync('pkill -9 -f "Antigravity IDE"', { stdio: 'ignore' });
       }
     } catch {
       // Ignore
@@ -385,7 +389,7 @@ export async function _waitForProcessExit(
     }
     await new Promise((resolve) => setTimeout(resolve, pollInterval));
   }
-  throw new Error(`Antigravity process did not exit within ${timeoutMs}ms`);
+  throw new Error(`Antigravity IDE process did not exit within ${timeoutMs}ms`);
 }
 
 /**
@@ -443,13 +447,13 @@ function shouldUseLinuxGpuSafeLaunchArgs(): boolean {
 
 async function startAntigravityByExecutable(execPath: string): Promise<void> {
   if (process.platform === 'darwin') {
-    await execAsync(`open -a Antigravity`);
+    await execAsync(`open -a "Antigravity IDE"`);
     return;
   }
 
   if (process.platform === 'win32') {
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity executable path');
+      throw new Error('Unable to locate Antigravity IDE executable path');
     }
     // Use start command to detach
     await execAsync(`start "" "${execPath}"`);
@@ -458,7 +462,7 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
 
   if (isWsl()) {
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity executable path');
+      throw new Error('Unable to locate Antigravity IDE executable path');
     }
     // In WSL, convert path and use cmd.exe
     const winPath = execPath
@@ -470,7 +474,7 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
   }
 
   if (!execPath) {
-    throw new Error('Unable to locate Antigravity executable path');
+    throw new Error('Unable to locate Antigravity IDE executable path');
   }
 
   const launchArgs = shouldUseLinuxGpuSafeLaunchArgs() ? [...LINUX_GPU_SAFE_LAUNCH_ARGS] : [];
@@ -491,31 +495,31 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
  * @returns {Promise<void>} A promise that resolves when the process starts.
  */
 export async function startAntigravity(useUri = true): Promise<void> {
-  logger.info('Starting Antigravity...');
+  logger.info('Starting Antigravity IDE...');
 
   if (await isProcessRunning()) {
-    logger.info('Antigravity is already running');
+    logger.info('Antigravity IDE is already running');
     return;
   }
 
   if (useUri) {
     logger.info('Using URI protocol to start...');
-    const uri = 'antigravity://oauth-success';
+    const uri = 'antigravity-ide://oauth-success';
 
     if (await openUri(uri)) {
-      logger.info('Antigravity URI launch command sent');
+      logger.info('Antigravity IDE URI launch command sent');
 
       if (process.platform !== 'linux' || isWsl()) {
         return;
       }
 
       if (await waitForAntigravityStartup()) {
-        logger.info('Antigravity process detected after URI launch');
+        logger.info('Antigravity IDE process detected after URI launch');
         return;
       }
 
       logger.warn(
-        'URI launch did not keep Antigravity running on Linux. Falling back to executable launch.',
+        'URI launch did not keep Antigravity IDE running on Linux. Falling back to executable launch.',
       );
     } else {
       logger.warn('URI launch failed, trying executable path...');
@@ -528,18 +532,18 @@ export async function startAntigravity(useUri = true): Promise<void> {
 
   try {
     await startAntigravityByExecutable(execPath);
-    logger.info('Antigravity launch command sent');
+    logger.info('Antigravity IDE launch command sent');
 
     if (process.platform === 'linux' && !isWsl()) {
       const started = await waitForAntigravityStartup();
       if (!started) {
         logger.warn(
-          'Antigravity launch command completed, but process startup could not be confirmed on Linux.',
+          'Antigravity IDE launch command completed, but process startup could not be confirmed on Linux.',
         );
       }
     }
   } catch (error) {
-    logger.error('Failed to start Antigravity via executable', error);
+    logger.error('Failed to start Antigravity IDE via executable', error);
     throw error;
   }
 }

--- a/src/ipc/process/handler.ts
+++ b/src/ipc/process/handler.ts
@@ -2,8 +2,14 @@ import { exec, execSync, spawn } from 'child_process';
 import { promisify } from 'util';
 import findProcess, { ProcessInfo } from 'find-process';
 import { isNumber } from 'lodash-es';
-import { getAntigravityExecutablePath, isWsl } from '../../utils/paths';
+import {
+  getAntigravityExecutablePathForEdition,
+  getIdeEditionAppName,
+  getIdeEditionUriProtocol,
+  isWsl,
+} from '../../utils/paths';
 import { logger } from '../../utils/logger';
+import type { IdeEdition } from '../../types/config';
 
 const execAsync = promisify(exec);
 const PROCESS_STARTUP_TIMEOUT_MS = 6000;
@@ -69,16 +75,21 @@ function isPgrepNoMatchError(error: unknown): boolean {
 /**
  * Checks if the Antigravity process is running.
  * Uses find-process package for robust cross-platform process detection.
+ * @param edition The IDE edition to check ('1.x' or '2.0'). Defaults to '1.x' for backward compatibility.
  * @returns {boolean} True if the Antigravity process is running, false otherwise.
  */
-export async function isProcessRunning(): Promise<boolean> {
+export async function isProcessRunning(edition?: IdeEdition): Promise<boolean> {
   try {
     const platform = process.platform;
     const currentPid = process.pid;
+    const targetEdition = edition ?? '1.x';
+
+    const appName = targetEdition === '2.0' ? 'Antigravity IDE' : 'Antigravity';
+    const appNameLower = appName.toLowerCase();
 
     // Use find-process to search for Antigravity processes
     const allMatches: ProcessInfo[] = [];
-    const searchNames = ['Antigravity', 'antigravity'];
+    const searchNames = [appName, appNameLower];
     if (platform === 'linux') {
       searchNames.push('electron');
     }
@@ -106,10 +117,10 @@ export async function isProcessRunning(): Promise<boolean> {
 
     const processes = Array.from(processMap.values());
     if (processes.length === 0 && sawNoMatch) {
-      logger.debug('No Antigravity process found (pgrep returned 1)');
+      logger.debug(`No ${appName} process found (pgrep returned 1)`);
     }
 
-    logger.debug(`Found ${processes.length} processes matching 'Antigravity/antigravity'`);
+    logger.debug(`Found ${processes.length} processes matching '${appName}'`);
 
     for (const proc of processes) {
       // Skip self
@@ -135,22 +146,21 @@ export async function isProcessRunning(): Promise<boolean> {
       }
 
       if (platform === 'darwin') {
-        // macOS: Check for Antigravity.app in path
-        if (cmd.includes('antigravity.app')) {
+        const appBundle = targetEdition === '2.0' ? 'antigravity ide.app' : 'antigravity.app';
+        if (cmd.includes(appBundle)) {
           logger.debug(
-            `Found Antigravity process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+            `Found ${appName} process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
           );
           return true;
         }
-        // Also check if the process name is exactly 'Antigravity' (main process)
-        if (name === 'antigravity' && !isHelperProcess(name, cmd)) {
-          logger.debug(`Found Antigravity process: PID=${proc.pid}, name=${name}`);
+        if (name === appNameLower && !isHelperProcess(name, cmd)) {
+          logger.debug(`Found ${appName} process: PID=${proc.pid}, name=${name}`);
           return true;
         }
       } else if (platform === 'win32') {
-        // Windows: Check for Antigravity.exe
-        if (name === 'antigravity.exe' || name === 'antigravity') {
-          logger.debug(`Found Antigravity process: PID=${proc.pid}, name=${name}`);
+        const exeName = targetEdition === '2.0' ? 'antigravity ide.exe' : 'antigravity.exe';
+        if (name === exeName || name === appNameLower) {
+          logger.debug(`Found ${appName} process: PID=${proc.pid}, name=${name}`);
           return true;
         }
       } else {
@@ -158,29 +168,27 @@ export async function isProcessRunning(): Promise<boolean> {
         const cmdLower = cmd.toLowerCase();
 
         if (nameLower === 'electron') {
-          // Stricter check for AUR/Electron wrapper:
-          // Must include antigravity in command line but NOT manager or tools
           const isAntigravityApp =
-            (cmdLower.includes('/antigravity') ||
-              cmdLower.includes(' antigravity') ||
-              cmdLower.endsWith('antigravity')) &&
+            (cmdLower.includes(`/${appNameLower}`) ||
+              cmdLower.includes(` ${appNameLower}`) ||
+              cmdLower.endsWith(appNameLower)) &&
             !cmdLower.includes('manager') &&
             !cmdLower.includes('tools');
 
           if (isAntigravityApp) {
             logger.debug(
-              `Found Antigravity (AUR/electron) process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+              `Found ${appName} (AUR/electron) process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
             );
             return true;
           }
         }
 
         if (
-          (name.includes('antigravity') || cmd.includes('/antigravity')) &&
+          (name.includes(appNameLower) || cmd.includes(`/${appNameLower}`)) &&
           !name.includes('tools')
         ) {
           logger.debug(
-            `Found Antigravity process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
+            `Found ${appName} process: PID=${proc.pid}, name=${name}, cmd=${cmd.substring(0, 100)}`,
           );
           return true;
         }
@@ -196,10 +204,15 @@ export async function isProcessRunning(): Promise<boolean> {
 
 /**
  * Closes the Antigravity process.
+ * @param edition The IDE edition to close ('1.x' or '2.0'). Defaults to '1.x'.
  * @returns {boolean} True if the Antigravity process is running, false otherwise.
  */
-export async function closeAntigravity(): Promise<void> {
-  logger.info('Closing Antigravity...');
+export async function closeAntigravity(edition?: IdeEdition): Promise<void> {
+  const targetEdition = edition ?? '1.x';
+  const appName = getIdeEditionAppName(targetEdition);
+  const exeName = targetEdition === '2.0' ? 'Antigravity IDE.exe' : 'Antigravity.exe';
+
+  logger.info(`Closing ${appName}...`);
   const platform = process.platform;
 
   try {
@@ -207,8 +220,8 @@ export async function closeAntigravity(): Promise<void> {
     if (platform === 'darwin') {
       // macOS: Use AppleScript to quit gracefully
       try {
-        logger.info('Attempting graceful exit via AppleScript...');
-        execSync('osascript -e \'tell application "Antigravity" to quit\'', {
+        logger.info(`Attempting graceful exit via AppleScript for ${appName}...`);
+        execSync(`osascript -e 'tell application "${appName}" to quit'`, {
           stdio: 'ignore',
           timeout: 3000,
         });
@@ -221,9 +234,7 @@ export async function closeAntigravity(): Promise<void> {
       // Windows: Use taskkill /IM (without /F) for graceful close
       try {
         logger.info('Attempting graceful exit via taskkill...');
-        // /T = Tree (child processes), /IM = Image Name
-        // We do not wait long here.
-        execSync('taskkill /IM "Antigravity.exe" /T', {
+        execSync(`taskkill /IM "${exeName}" /T`, {
           stdio: 'ignore',
           timeout: 2000,
         });
@@ -234,7 +245,6 @@ export async function closeAntigravity(): Promise<void> {
     }
 
     // Stage 2 & 3: Find and Kill remaining processes
-    // We use a more aggressive approach here but try to avoid killing ourselves
     const currentPid = process.pid;
 
     // Helper to list processes
@@ -252,19 +262,16 @@ export async function closeAntigravity(): Promise<void> {
               stdio: ['pipe', 'pipe', 'ignore'],
             });
           } catch (e) {
-            // CIM failed (likely older OS), try WMI
             try {
               output = execSync(psCommand('Get-WmiObject'), {
                 encoding: 'utf-8',
                 maxBuffer: 1024 * 1024 * 10,
               });
             } catch (innerE) {
-              // Both failed, throw original or log? Throwing lets the outer catch handle it (returning empty list)
               throw e;
             }
           }
         } else {
-          // Unix/Linux/macOS
           output = execSync('ps -A -o pid,comm,args', {
             encoding: 'utf-8',
             maxBuffer: 1024 * 1024 * 10,
@@ -274,17 +281,13 @@ export async function closeAntigravity(): Promise<void> {
         const processList: { pid: number; name: string; cmd: string }[] = [];
 
         if (platform === 'win32') {
-          // Parse CSV Output
           const lines = output.trim().split(/\r?\n/);
-          // First line is headers "ProcessId","Name","CommandLine"
-          // We start from index 1
           for (let i = 1; i < lines.length; i++) {
             const line = lines[i];
             if (!line) {
               continue;
             }
 
-            // Regex to match CSV fields: "val1","val2","val3"
             const match = line.match(/^"(\d+)","(.*?)","(.*?)"$/);
 
             if (match) {
@@ -304,7 +307,7 @@ export async function closeAntigravity(): Promise<void> {
             const pid = parseInt(parts[0]);
             if (isNaN(pid)) continue;
             const rest = parts.slice(1).join(' ');
-            if (rest.includes('Antigravity') || rest.includes('antigravity')) {
+            if (rest.includes(appName) || rest.includes(appName.toLowerCase())) {
               processList.push({ pid, name: parts[1], cmd: rest });
             }
           }
@@ -317,51 +320,46 @@ export async function closeAntigravity(): Promise<void> {
     };
 
     const targetProcessList = getProcesses().filter((p) => {
-      // Exclude self
       if (p.pid === currentPid) {
         return false;
       }
-      // Exclude this electron app (if named Antigravity Manager or antigravity-manager)
       if (p.cmd.includes('Antigravity Manager') || p.cmd.includes('antigravity-manager')) {
         return false;
       }
-      // Match Antigravity (but not manager)
       if (platform === 'win32') {
         return (
-          p.cmd.includes('Antigravity.exe') ||
-          (p.cmd.includes('antigravity') && !p.cmd.includes('manager'))
+          p.cmd.includes(exeName) ||
+          (p.cmd.includes(appName.toLowerCase()) && !p.cmd.includes('manager'))
         );
       } else {
-        // Explicit !manager check for Linux/macOS to be defensive
         return (
-          (p.cmd.includes('Antigravity') || p.cmd.includes('antigravity')) &&
+          (p.cmd.includes(appName) || p.cmd.includes(appName.toLowerCase())) &&
           !p.cmd.includes('manager')
         );
       }
     });
 
     if (targetProcessList.length === 0) {
-      logger.info('No Antigravity processes found running.');
+      logger.info(`No ${appName} processes found running.`);
       return;
     }
 
-    logger.info(`Found ${targetProcessList.length} remaining Antigravity processes. Killing...`);
+    logger.info(`Found ${targetProcessList.length} remaining ${appName} processes. Killing...`);
 
     for (const p of targetProcessList) {
       try {
-        process.kill(p.pid, 'SIGKILL'); // Force kill as final step
+        process.kill(p.pid, 'SIGKILL');
       } catch {
         // Ignore if already dead
       }
     }
   } catch (error) {
-    logger.error('Error closing Antigravity', error);
-    // Fallback to simple kill if everything fails
+    logger.error(`Error closing ${appName}`, error);
     try {
       if (platform === 'win32') {
-        execSync('taskkill /F /IM "Antigravity.exe" /T', { stdio: 'ignore' });
+        execSync(`taskkill /F /IM "${exeName}" /T`, { stdio: 'ignore' });
       } else {
-        execSync('pkill -9 -f Antigravity', { stdio: 'ignore' });
+        execSync(`pkill -9 -f "${appName}"`, { stdio: 'ignore' });
       }
     } catch {
       // Ignore
@@ -421,10 +419,11 @@ async function openUri(uri: string): Promise<boolean> {
 async function waitForAntigravityStartup(
   timeoutMs = PROCESS_STARTUP_TIMEOUT_MS,
   pollIntervalMs = PROCESS_STARTUP_POLL_INTERVAL_MS,
+  edition?: IdeEdition,
 ): Promise<boolean> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (await isProcessRunning()) {
+    if (await isProcessRunning(edition)) {
       return true;
     }
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
@@ -441,26 +440,28 @@ function shouldUseLinuxGpuSafeLaunchArgs(): boolean {
   return enableLinuxGpuRaw !== '1' && enableLinuxGpuRaw !== 'true';
 }
 
-async function startAntigravityByExecutable(execPath: string): Promise<void> {
+async function startAntigravityByExecutable(
+  execPath: string,
+  edition: IdeEdition,
+): Promise<void> {
   if (process.platform === 'darwin') {
-    await execAsync(`open -a Antigravity`);
+    const appName = getIdeEditionAppName(edition);
+    await execAsync(`open -a "${appName}"`);
     return;
   }
 
   if (process.platform === 'win32') {
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity executable path');
+      throw new Error(`Unable to locate ${getIdeEditionAppName(edition)} executable path`);
     }
-    // Use start command to detach
     await execAsync(`start "" "${execPath}"`);
     return;
   }
 
   if (isWsl()) {
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity executable path');
+      throw new Error(`Unable to locate ${getIdeEditionAppName(edition)} executable path`);
     }
-    // In WSL, convert path and use cmd.exe
     const winPath = execPath
       .replace(/^\/mnt\/([a-z])\//, (_, drive) => `${drive.toUpperCase()}:\\`)
       .replace(/\//g, '\\');
@@ -470,7 +471,7 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
   }
 
   if (!execPath) {
-    throw new Error('Unable to locate Antigravity executable path');
+    throw new Error(`Unable to locate ${getIdeEditionAppName(edition)} executable path`);
   }
 
   const launchArgs = shouldUseLinuxGpuSafeLaunchArgs() ? [...LINUX_GPU_SAFE_LAUNCH_ARGS] : [];
@@ -487,35 +488,40 @@ async function startAntigravityByExecutable(execPath: string): Promise<void> {
 
 /**
  * Starts the Antigravity process.
+ * @param edition The IDE edition to start ('1.x' or '2.0'). Defaults to '1.x'.
  * @param useUri {boolean} Whether to use the URI protocol to start Antigravity.
  * @returns {Promise<void>} A promise that resolves when the process starts.
  */
-export async function startAntigravity(useUri = true): Promise<void> {
-  logger.info('Starting Antigravity...');
+export async function startAntigravity(edition?: IdeEdition, useUri = true): Promise<void> {
+  const targetEdition = edition ?? '1.x';
+  const appName = getIdeEditionAppName(targetEdition);
 
-  if (await isProcessRunning()) {
-    logger.info('Antigravity is already running');
+  logger.info(`Starting ${appName}...`);
+
+  if (await isProcessRunning(targetEdition)) {
+    logger.info(`${appName} is already running`);
     return;
   }
 
   if (useUri) {
     logger.info('Using URI protocol to start...');
-    const uri = 'antigravity://oauth-success';
+    const uriProtocol = getIdeEditionUriProtocol(targetEdition);
+    const uri = `${uriProtocol}://oauth-success`;
 
     if (await openUri(uri)) {
-      logger.info('Antigravity URI launch command sent');
+      logger.info(`${appName} URI launch command sent`);
 
       if (process.platform !== 'linux' || isWsl()) {
         return;
       }
 
-      if (await waitForAntigravityStartup()) {
-        logger.info('Antigravity process detected after URI launch');
+      if (await waitForAntigravityStartup(undefined, undefined, targetEdition)) {
+        logger.info(`${appName} process detected after URI launch`);
         return;
       }
 
       logger.warn(
-        'URI launch did not keep Antigravity running on Linux. Falling back to executable launch.',
+        `URI launch did not keep ${appName} running on Linux. Falling back to executable launch.`,
       );
     } else {
       logger.warn('URI launch failed, trying executable path...');
@@ -524,22 +530,22 @@ export async function startAntigravity(useUri = true): Promise<void> {
 
   // Fallback to executable path
   logger.info('Using executable path to start...');
-  const execPath = getAntigravityExecutablePath();
+  const execPath = getAntigravityExecutablePathForEdition(targetEdition);
 
   try {
-    await startAntigravityByExecutable(execPath);
-    logger.info('Antigravity launch command sent');
+    await startAntigravityByExecutable(execPath, targetEdition);
+    logger.info(`${appName} launch command sent`);
 
     if (process.platform === 'linux' && !isWsl()) {
-      const started = await waitForAntigravityStartup();
+      const started = await waitForAntigravityStartup(undefined, undefined, targetEdition);
       if (!started) {
         logger.warn(
-          'Antigravity launch command completed, but process startup could not be confirmed on Linux.',
+          `${appName} launch command completed, but process startup could not be confirmed on Linux.`,
         );
       }
     }
   } catch (error) {
-    logger.error('Failed to start Antigravity via executable', error);
+    logger.error(`Failed to start ${appName} via executable`, error);
     throw error;
   }
 }

--- a/src/ipc/process/handler.ts
+++ b/src/ipc/process/handler.ts
@@ -374,11 +374,12 @@ export async function closeAntigravity(edition?: IdeEdition): Promise<void> {
  */
 export async function _waitForProcessExit(
   timeoutMs: number,
-  pollInterval = 100, // Make it configurable, but keep fast 100ms default
+  pollInterval = 100,
+  edition?: IdeEdition,
 ): Promise<void> {
   const startTime = Date.now();
   while (Date.now() - startTime < timeoutMs) {
-    if (!(await isProcessRunning())) {
+    if (!(await isProcessRunning(edition))) {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, pollInterval));

--- a/src/ipc/router.ts
+++ b/src/ipc/router.ts
@@ -12,6 +12,8 @@ import { z } from 'zod';
 import { isProcessRunning, closeAntigravity, startAntigravity } from './process/handler';
 import { systemHandler } from './system/handler';
 import { logger } from '../utils/logger';
+import { ConfigManager } from './config/manager';
+import type { IdeEdition } from '../types/config';
 
 // Log middleware setup
 const logMiddleware = os.middleware(async (opts: any) => {
@@ -27,6 +29,11 @@ const logMiddleware = os.middleware(async (opts: any) => {
   }
 });
 
+function getEdition(): IdeEdition | undefined {
+  const config = ConfigManager.getCachedConfig() || ConfigManager.loadConfig();
+  return config.ideEdition || undefined;
+}
+
 // Explicit Router Definition
 export const router = os.use(logMiddleware).router({
   ping: os.output(z.string()).handler(async () => 'pong'),
@@ -39,13 +46,13 @@ export const router = os.use(logMiddleware).router({
   // Inline process router to ensure structure
   proc: os.router({
     isProcessRunning: os.output(z.boolean()).handler(async () => {
-      return await isProcessRunning();
+      return await isProcessRunning(getEdition());
     }),
     closeAntigravity: os.output(z.void()).handler(async () => {
-      await closeAntigravity();
+      await closeAntigravity(getEdition());
     }),
     startAntigravity: os.output(z.void()).handler(async () => {
-      await startAntigravity();
+      await startAntigravity(getEdition());
     }),
   }),
 

--- a/src/ipc/switchFlow.ts
+++ b/src/ipc/switchFlow.ts
@@ -15,7 +15,7 @@ export interface SwitchFlowOptions {
   applyFingerprint: boolean;
   processExitTimeoutMs: number;
   edition?: IdeEdition;
-  performSwitch: () => Promise<void>;
+  performSwitch: (edition?: IdeEdition) => Promise<void>;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -78,7 +78,7 @@ export async function executeSwitchFlow(options: SwitchFlowOptions): Promise<voi
     }
 
     stage = 'switch';
-    await performSwitch();
+    await performSwitch(edition);
     stage = 'start';
     await startAntigravity(edition);
     recordSwitchSuccess(scope);

--- a/src/ipc/switchFlow.ts
+++ b/src/ipc/switchFlow.ts
@@ -7,12 +7,14 @@ import {
   recordSwitchFailure,
   recordSwitchSuccess,
 } from './switchMetrics';
+import type { IdeEdition } from '../types/config';
 
 export interface SwitchFlowOptions {
   scope: 'local' | 'cloud';
   targetProfile: DeviceProfile | null;
   applyFingerprint: boolean;
   processExitTimeoutMs: number;
+  edition?: IdeEdition;
   performSwitch: () => Promise<void>;
 }
 
@@ -51,13 +53,13 @@ function toSwitchFailureReason(stage: string, error: unknown): SwitchFailureReas
 }
 
 export async function executeSwitchFlow(options: SwitchFlowOptions): Promise<void> {
-  const { scope, targetProfile, applyFingerprint, processExitTimeoutMs, performSwitch } = options;
+  const { scope, targetProfile, applyFingerprint, processExitTimeoutMs, edition, performSwitch } = options;
 
   let stage = 'close';
   try {
-    await closeAntigravity();
+    await closeAntigravity(edition);
     try {
-      await _waitForProcessExit(processExitTimeoutMs);
+      await _waitForProcessExit(processExitTimeoutMs, 100, edition);
     } catch (error) {
       logger.warn('Process did not exit cleanly within timeout, but proceeding...', error);
     }
@@ -78,7 +80,7 @@ export async function executeSwitchFlow(options: SwitchFlowOptions): Promise<voi
     stage = 'switch';
     await performSwitch();
     stage = 'start';
-    await startAntigravity();
+    await startAntigravity(edition);
     recordSwitchSuccess(scope);
   } catch (error) {
     const reason = toSwitchFailureReason(stage, error);

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -87,7 +87,7 @@ export const MainLayout: React.FC = () => {
                   isCollapsed ? 'w-0 opacity-0' : 'w-auto opacity-100',
                 )}
               >
-                <h1 className="text-xl font-bold tracking-tight">Antigravity IDE</h1>
+                <h1 className="text-xl font-bold tracking-tight">Antigravity</h1>
               </div>
             </div>
             <div

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -87,7 +87,7 @@ export const MainLayout: React.FC = () => {
                   isCollapsed ? 'w-0 opacity-0' : 'w-auto opacity-100',
                 )}
               >
-                <h1 className="text-xl font-bold tracking-tight">Antigravity</h1>
+                <h1 className="text-xl font-bold tracking-tight">Antigravity IDE</h1>
               </div>
             </div>
             <div

--- a/src/localization/i18n.ts
+++ b/src/localization/i18n.ts
@@ -62,6 +62,19 @@ i18n
             proxy: 'API Proxy',
             settings: 'Settings',
           },
+          editionSelection: {
+            title: 'Choose Your Antigravity Edition',
+            description: 'Select which version of Antigravity you are using. This helps the Manager connect to the correct application.',
+            edition1x: {
+              name: 'Antigravity 1.x',
+              description: 'The original Antigravity application. Choose this if you are using the legacy version.',
+            },
+            edition20: {
+              name: 'Antigravity IDE',
+              description: 'The new Antigravity IDE (2.0). Choose this if you are using the latest IDE version.',
+            },
+            confirm: 'Continue',
+          },
           account: {
             current: 'Current',
             lastUsed: 'Last used {{time}}',
@@ -95,6 +108,13 @@ i18n
               russian: 'Russian',
               vietnamese: 'Vietnamese',
               turkish: 'Turkish',
+            },
+            ideEdition: {
+              title: 'Antigravity Edition',
+              description: 'Select which version of Antigravity you are using.',
+              placeholder: 'Select edition',
+              edition1x: 'Antigravity 1.x',
+              edition20: 'Antigravity IDE',
             },
             about: {
               title: 'About',
@@ -543,6 +563,19 @@ i18n
             proxy: 'API 反代',
             settings: '设置',
           },
+          editionSelection: {
+            title: '选择您的 Antigravity 版本',
+            description: '选择您正在使用的 Antigravity 版本。这将帮助管理器连接到正确的应用程序。',
+            edition1x: {
+              name: 'Antigravity 1.x',
+              description: '原始 Antigravity 应用程序。如果您使用的是旧版本，请选择此项。',
+            },
+            edition20: {
+              name: 'Antigravity IDE',
+              description: '新版 Antigravity IDE (2.0)。如果您使用的是最新的 IDE 版本，请选择此项。',
+            },
+            confirm: '继续',
+          },
           account: {
             current: '当前',
             lastUsed: '上次使用 {{time}}',
@@ -576,6 +609,13 @@ i18n
               russian: '俄语',
               vietnamese: '越南语',
               turkish: '土耳其语',
+            },
+            ideEdition: {
+              title: 'Antigravity 版本',
+              description: '选择您正在使用的 Antigravity 版本。',
+              placeholder: '选择版本',
+              edition1x: 'Antigravity 1.x',
+              edition20: 'Antigravity IDE',
             },
             about: {
               title: '关于',
@@ -1012,6 +1052,19 @@ i18n
             proxy: 'API Прокси',
             settings: 'Настройки',
           },
+          editionSelection: {
+            title: 'Выберите версию Antigravity',
+            description: 'Выберите, какую версию Antigravity вы используете. Это поможет менеджеру подключиться к правильному приложению.',
+            edition1x: {
+              name: 'Antigravity 1.x',
+              description: 'Оригинальное приложение Antigravity. Выберите это, если вы используете устаревшую версию.',
+            },
+            edition20: {
+              name: 'Antigravity IDE',
+              description: 'Новый Antigravity IDE (2.0). Выберите это, если вы используете последнюю версию IDE.',
+            },
+            confirm: 'Продолжить',
+          },
           account: {
             current: 'Текущий',
             lastUsed: 'Последнее использование {{time}}',
@@ -1046,6 +1099,13 @@ i18n
               russian: 'Русский',
               vietnamese: 'Вьетнамский',
               turkish: 'Турецкий',
+            },
+            ideEdition: {
+              title: 'Версия Antigravity',
+              description: 'Выберите, какую версию Antigravity вы используете.',
+              placeholder: 'Выберите версию',
+              edition1x: 'Antigravity 1.x',
+              edition20: 'Antigravity IDE',
             },
             about: {
               title: 'О программе',

--- a/src/localization/i18n.ts
+++ b/src/localization/i18n.ts
@@ -29,8 +29,8 @@ i18n
           },
           status: {
             checking: 'Checking status...',
-            running: 'Antigravity IDE is running in background',
-            stopped: 'Antigravity IDE service stopped',
+            running: 'Antigravity is running in background',
+            stopped: 'Antigravity service stopped',
           },
           action: {
             stop: 'Stop',
@@ -68,10 +68,10 @@ i18n
           },
           home: {
             title: 'Accounts',
-            description: 'Manage your Antigravity IDE Google Gemini accounts.',
+            description: 'Manage your Antigravity Google Gemini accounts.',
             noBackups: {
               title: 'No backups found',
-              description: 'Create a backup of your current Antigravity IDE account to get started.',
+              description: 'Create a backup of your current Antigravity account to get started.',
               action: 'Backup Current Account',
             },
           },
@@ -158,7 +158,7 @@ i18n
             modelMapping: {
               title: 'Model Mapping',
               description:
-                'Map Claude Code models to Antigravity IDE models. Optimize cost and speed by routing requests intelligently.',
+                'Map Claude Code models to Antigravity models. Optimize cost and speed by routing requests intelligently.',
               claudeKeyword: 'Claude Model (Keyword)',
               targetGemini: 'Target Gemini Model',
               addPlaceholderKey: 'e.g. op-3',
@@ -383,7 +383,7 @@ i18n
               pollFailed: 'Failed to poll quota for all accounts',
               switched: {
                 title: 'Account switched!',
-                description: 'Restarting Antigravity IDE...',
+                description: 'Restarting Antigravity...',
               },
               switchFailed: 'Failed to switch account',
               deleted: 'Account deleted',
@@ -510,8 +510,8 @@ i18n
           },
           status: {
             checking: '正在检查状态...',
-            running: 'Antigravity IDE 正在后台运行',
-            stopped: 'Antigravity IDE 服务已停止',
+            running: 'Antigravity 正在后台运行',
+            stopped: 'Antigravity 服务已停止',
           },
           action: {
             stop: '停止',
@@ -549,10 +549,10 @@ i18n
           },
           home: {
             title: '账号列表',
-            description: '管理您的 Antigravity IDE Google Gemini 账号。',
+            description: '管理您的 Antigravity Google Gemini 账号。',
             noBackups: {
               title: '未找到备份',
-              description: '备份您当前的 Antigravity IDE 账号以开始使用。',
+              description: '备份您当前的 Antigravity 账号以开始使用。',
               action: '备份当前账号',
             },
           },
@@ -637,7 +637,7 @@ i18n
             modelMapping: {
               title: '模型映射',
               description:
-                '将 Claude Code 模型映射到 Antigravity IDE 模型，智能路由请求以优化成本和速度。',
+                '将 Claude Code 模型映射到 Antigravity 模型，智能路由请求以优化成本和速度。',
               claudeKeyword: 'Claude 模型 (关键词)',
               targetGemini: '目标 Gemini 模型',
               addPlaceholderKey: '例如 op-3',
@@ -859,7 +859,7 @@ i18n
               pollFailed: '轮询所有账号配额失败',
               switched: {
                 title: '账号已切换！',
-                description: '正在重启 Antigravity IDE...',
+                description: '正在重启 Antigravity...',
               },
               switchFailed: '切换账号失败',
               deleted: '账号已删除',
@@ -979,8 +979,8 @@ i18n
           },
           status: {
             checking: 'Проверка статуса...',
-            running: 'Antigravity IDE работает в фоне',
-            stopped: 'Служба Antigravity IDE остановлена',
+            running: 'Antigravity работает в фоне',
+            stopped: 'Служба Antigravity остановлена',
           },
           action: {
             stop: 'Стоп',
@@ -1018,11 +1018,11 @@ i18n
           },
           home: {
             title: 'Аккаунты',
-            description: 'Управление вашими аккаунтами Antigravity IDE Google Gemini.',
+            description: 'Управление вашими аккаунтами Antigravity Google Gemini.',
             noBackups: {
               title: 'Бэкапы не найдены',
               description:
-                'Создайте резервную копию вашего текущего аккаунта Antigravity IDE, чтобы начать.',
+                'Создайте резервную копию вашего текущего аккаунта Antigravity, чтобы начать.',
               action: 'Создать бэкап текущего аккаунта',
             },
           },
@@ -1110,7 +1110,7 @@ i18n
             modelMapping: {
               title: 'Маппинг моделей',
               description:
-                'Сопоставьте модели Claude Code с моделями Antigravity IDE. Оптимизируйте затраты и скорость, разумно маршрутизируя запросы.',
+                'Сопоставьте модели Claude Code с моделями Antigravity. Оптимизируйте затраты и скорость, разумно маршрутизируя запросы.',
               claudeKeyword: 'Модель Claude (Ключевое слово)',
               targetGemini: 'Целевая модель Gemini',
               addPlaceholderKey: 'например, op-3',
@@ -1334,7 +1334,7 @@ i18n
               pollFailed: 'Не удалось опросить квоты всех аккаунтов',
               switched: {
                 title: 'Аккаунт переключен!',
-                description: 'Перезапуск Antigravity IDE...',
+                description: 'Перезапуск Antigravity...',
               },
               switchFailed: 'Не удалось переключить аккаунт',
               deleted: 'Аккаунт удален',

--- a/src/localization/i18n.ts
+++ b/src/localization/i18n.ts
@@ -29,8 +29,8 @@ i18n
           },
           status: {
             checking: 'Checking status...',
-            running: 'Antigravity is running in background',
-            stopped: 'Antigravity service stopped',
+            running: 'Antigravity IDE is running in background',
+            stopped: 'Antigravity IDE service stopped',
           },
           action: {
             stop: 'Stop',
@@ -68,10 +68,10 @@ i18n
           },
           home: {
             title: 'Accounts',
-            description: 'Manage your Antigravity Google Gemini accounts.',
+            description: 'Manage your Antigravity IDE Google Gemini accounts.',
             noBackups: {
               title: 'No backups found',
-              description: 'Create a backup of your current Antigravity account to get started.',
+              description: 'Create a backup of your current Antigravity IDE account to get started.',
               action: 'Backup Current Account',
             },
           },
@@ -158,7 +158,7 @@ i18n
             modelMapping: {
               title: 'Model Mapping',
               description:
-                'Map Claude Code models to Antigravity models. Optimize cost and speed by routing requests intelligently.',
+                'Map Claude Code models to Antigravity IDE models. Optimize cost and speed by routing requests intelligently.',
               claudeKeyword: 'Claude Model (Keyword)',
               targetGemini: 'Target Gemini Model',
               addPlaceholderKey: 'e.g. op-3',
@@ -383,7 +383,7 @@ i18n
               pollFailed: 'Failed to poll quota for all accounts',
               switched: {
                 title: 'Account switched!',
-                description: 'Restarting Antigravity...',
+                description: 'Restarting Antigravity IDE...',
               },
               switchFailed: 'Failed to switch account',
               deleted: 'Account deleted',
@@ -510,8 +510,8 @@ i18n
           },
           status: {
             checking: '正在检查状态...',
-            running: 'Antigravity 正在后台运行',
-            stopped: 'Antigravity 服务已停止',
+            running: 'Antigravity IDE 正在后台运行',
+            stopped: 'Antigravity IDE 服务已停止',
           },
           action: {
             stop: '停止',
@@ -549,10 +549,10 @@ i18n
           },
           home: {
             title: '账号列表',
-            description: '管理您的 Antigravity Google Gemini 账号。',
+            description: '管理您的 Antigravity IDE Google Gemini 账号。',
             noBackups: {
               title: '未找到备份',
-              description: '备份您当前的 Antigravity 账号以开始使用。',
+              description: '备份您当前的 Antigravity IDE 账号以开始使用。',
               action: '备份当前账号',
             },
           },
@@ -637,7 +637,7 @@ i18n
             modelMapping: {
               title: '模型映射',
               description:
-                '将 Claude Code 模型映射到 Antigravity 模型，智能路由请求以优化成本和速度。',
+                '将 Claude Code 模型映射到 Antigravity IDE 模型，智能路由请求以优化成本和速度。',
               claudeKeyword: 'Claude 模型 (关键词)',
               targetGemini: '目标 Gemini 模型',
               addPlaceholderKey: '例如 op-3',
@@ -859,7 +859,7 @@ i18n
               pollFailed: '轮询所有账号配额失败',
               switched: {
                 title: '账号已切换！',
-                description: '正在重启 Antigravity...',
+                description: '正在重启 Antigravity IDE...',
               },
               switchFailed: '切换账号失败',
               deleted: '账号已删除',
@@ -979,8 +979,8 @@ i18n
           },
           status: {
             checking: 'Проверка статуса...',
-            running: 'Antigravity работает в фоне',
-            stopped: 'Служба Antigravity остановлена',
+            running: 'Antigravity IDE работает в фоне',
+            stopped: 'Служба Antigravity IDE остановлена',
           },
           action: {
             stop: 'Стоп',
@@ -1018,11 +1018,11 @@ i18n
           },
           home: {
             title: 'Аккаунты',
-            description: 'Управление вашими аккаунтами Antigravity Google Gemini.',
+            description: 'Управление вашими аккаунтами Antigravity IDE Google Gemini.',
             noBackups: {
               title: 'Бэкапы не найдены',
               description:
-                'Создайте резервную копию вашего текущего аккаунта Antigravity, чтобы начать.',
+                'Создайте резервную копию вашего текущего аккаунта Antigravity IDE, чтобы начать.',
               action: 'Создать бэкап текущего аккаунта',
             },
           },
@@ -1110,7 +1110,7 @@ i18n
             modelMapping: {
               title: 'Маппинг моделей',
               description:
-                'Сопоставьте модели Claude Code с моделями Antigravity. Оптимизируйте затраты и скорость, разумно маршрутизируя запросы.',
+                'Сопоставьте модели Claude Code с моделями Antigravity IDE. Оптимизируйте затраты и скорость, разумно маршрутизируя запросы.',
               claudeKeyword: 'Модель Claude (Ключевое слово)',
               targetGemini: 'Целевая модель Gemini',
               addPlaceholderKey: 'например, op-3',
@@ -1334,7 +1334,7 @@ i18n
               pollFailed: 'Не удалось опросить квоты всех аккаунтов',
               switched: {
                 title: 'Аккаунт переключен!',
-                description: 'Перезапуск Antigravity...',
+                description: 'Перезапуск Antigravity IDE...',
               },
               switchFailed: 'Не удалось переключить аккаунт',
               deleted: 'Аккаунт удален',

--- a/src/localization/tr.ts
+++ b/src/localization/tr.ts
@@ -42,6 +42,19 @@ const tr = {
     proxy: 'API Proxy',
     settings: 'Ayarlar',
   },
+  editionSelection: {
+    title: 'Antigravity Sürümünüzü Seçin',
+    description: 'Kullandığınız Antigravity sürümünü seçin. Bu, Manager\'ın doğru uygulamaya bağlanmasını sağlar.',
+    edition1x: {
+      name: 'Antigravity 1.x',
+      description: 'Orijinal Antigravity uygulaması. Eski sürümü kullanıyorsanız bunu seçin.',
+    },
+    edition20: {
+      name: 'Antigravity IDE',
+      description: 'Yeni Antigravity IDE (2.0). En son IDE sürümünü kullanıyorsanız bunu seçin.',
+    },
+    confirm: 'Devam Et',
+  },
   account: {
     current: 'Mevcut',
     lastUsed: 'Son kullanım: {{time}}',
@@ -75,6 +88,13 @@ const tr = {
       russian: 'Rusça',
       vietnamese: 'Vietnamca',
       turkish: 'Türkçe',
+    },
+    ideEdition: {
+      title: 'Antigravity Sürümü',
+      description: 'Kullandığınız Antigravity sürümünü seçin.',
+      placeholder: 'Sürüm seçin',
+      edition1x: 'Antigravity 1.x',
+      edition20: 'Antigravity IDE',
     },
     about: {
       title: 'Hakkında',

--- a/src/localization/tr.ts
+++ b/src/localization/tr.ts
@@ -9,8 +9,8 @@ const tr = {
   },
   status: {
     checking: 'Durum kontrol ediliyor...',
-    running: 'Antigravity IDE arka planda çalışıyor',
-    stopped: 'Antigravity IDE hizmeti durduruldu',
+    running: 'Antigravity arka planda çalışıyor',
+    stopped: 'Antigravity hizmeti durduruldu',
   },
   action: {
     stop: 'Durdur',
@@ -48,10 +48,10 @@ const tr = {
   },
   home: {
     title: 'Hesaplar',
-    description: 'Antigravity IDE Google Gemini hesaplarınızı yönetin.',
+    description: 'Antigravity Google Gemini hesaplarınızı yönetin.',
     noBackups: {
       title: 'Yedek bulunamadı',
-      description: 'Başlamak için mevcut Antigravity IDE hesabınızın bir yedeğini oluşturun.',
+      description: 'Başlamak için mevcut Antigravity hesabınızın bir yedeğini oluşturun.',
       action: 'Mevcut Hesabı Yedekle',
     },
   },
@@ -138,7 +138,7 @@ const tr = {
     modelMapping: {
       title: 'Model Eşleme',
       description:
-        'Claude Code modellerini Antigravity IDE modelleriyle eşleyin. İstekleri akıllıca yönlendirerek maliyeti ve hızı optimize edin.',
+        'Claude Code modellerini Antigravity modelleriyle eşleyin. İstekleri akıllıca yönlendirerek maliyeti ve hızı optimize edin.',
       claudeKeyword: 'Claude Modeli (Anahtar Kelime)',
       targetGemini: 'Hedef Gemini Modeli',
       addPlaceholderKey: 'örn. op-3',
@@ -362,7 +362,7 @@ const tr = {
       pollFailed: 'Tüm hesaplar için kota sorgulanamadı',
       switched: {
         title: 'Hesap değiştirildi!',
-        description: 'Antigravity IDE yeniden başlatılıyor...',
+        description: 'Antigravity yeniden başlatılıyor...',
       },
       switchFailed: 'Hesap değiştirilemedi',
       deleted: 'Hesap silindi',

--- a/src/localization/tr.ts
+++ b/src/localization/tr.ts
@@ -9,8 +9,8 @@ const tr = {
   },
   status: {
     checking: 'Durum kontrol ediliyor...',
-    running: 'Antigravity arka planda çalışıyor',
-    stopped: 'Antigravity hizmeti durduruldu',
+    running: 'Antigravity IDE arka planda çalışıyor',
+    stopped: 'Antigravity IDE hizmeti durduruldu',
   },
   action: {
     stop: 'Durdur',
@@ -48,10 +48,10 @@ const tr = {
   },
   home: {
     title: 'Hesaplar',
-    description: 'Antigravity Google Gemini hesaplarınızı yönetin.',
+    description: 'Antigravity IDE Google Gemini hesaplarınızı yönetin.',
     noBackups: {
       title: 'Yedek bulunamadı',
-      description: 'Başlamak için mevcut Antigravity hesabınızın bir yedeğini oluşturun.',
+      description: 'Başlamak için mevcut Antigravity IDE hesabınızın bir yedeğini oluşturun.',
       action: 'Mevcut Hesabı Yedekle',
     },
   },
@@ -138,7 +138,7 @@ const tr = {
     modelMapping: {
       title: 'Model Eşleme',
       description:
-        'Claude Code modellerini Antigravity modelleriyle eşleyin. İstekleri akıllıca yönlendirerek maliyeti ve hızı optimize edin.',
+        'Claude Code modellerini Antigravity IDE modelleriyle eşleyin. İstekleri akıllıca yönlendirerek maliyeti ve hızı optimize edin.',
       claudeKeyword: 'Claude Modeli (Anahtar Kelime)',
       targetGemini: 'Hedef Gemini Modeli',
       addPlaceholderKey: 'örn. op-3',
@@ -362,7 +362,7 @@ const tr = {
       pollFailed: 'Tüm hesaplar için kota sorgulanamadı',
       switched: {
         title: 'Hesap değiştirildi!',
-        description: 'Antigravity yeniden başlatılıyor...',
+        description: 'Antigravity IDE yeniden başlatılıyor...',
       },
       switchFailed: 'Hesap değiştirilemedi',
       deleted: 'Hesap silindi',

--- a/src/localization/vi.ts
+++ b/src/localization/vi.ts
@@ -42,6 +42,19 @@ const vi = {
     proxy: 'API Proxy',
     settings: 'Cài đặt',
   },
+  editionSelection: {
+    title: 'Chọn phiên bản Antigravity',
+    description: 'Chọn phiên bản Antigravity bạn đang sử dụng. Điều này giúp Manager kết nối đúng ứng dụng.',
+    edition1x: {
+      name: 'Antigravity 1.x',
+      description: 'Ứng dụng Antigravity gốc. Chọn nếu bạn đang dùng phiên bản cũ.',
+    },
+    edition20: {
+      name: 'Antigravity IDE',
+      description: 'Antigravity IDE mới (2.0). Chọn nếu bạn đang dùng phiên bản IDE mới nhất.',
+    },
+    confirm: 'Tiếp tục',
+  },
   account: {
     current: 'Hiện tại',
     lastUsed: 'Đã dùng {{time}}',
@@ -75,6 +88,13 @@ const vi = {
       russian: 'Tiếng Nga',
       vietnamese: 'Tiếng Việt',
       turkish: 'Tiếng Thổ Nhĩ Kỳ',
+    },
+    ideEdition: {
+      title: 'Phiên bản Antigravity',
+      description: 'Chọn phiên bản Antigravity bạn đang sử dụng.',
+      placeholder: 'Chọn phiên bản',
+      edition1x: 'Antigravity 1.x',
+      edition20: 'Antigravity IDE',
     },
     about: {
       title: 'Thông tin',

--- a/src/localization/vi.ts
+++ b/src/localization/vi.ts
@@ -9,8 +9,8 @@ const vi = {
   },
   status: {
     checking: 'Đang kiểm tra trạng thái...',
-    running: 'Antigravity IDE đang chạy nền',
-    stopped: 'Dịch vụ Antigravity IDE đã dừng',
+    running: 'Antigravity đang chạy nền',
+    stopped: 'Dịch vụ Antigravity đã dừng',
   },
   action: {
     stop: 'Dừng',
@@ -48,10 +48,10 @@ const vi = {
   },
   home: {
     title: 'Tài khoản',
-    description: 'Quản lý các tài khoản Antigravity IDE Google Gemini.',
+    description: 'Quản lý các tài khoản Antigravity Google Gemini.',
     noBackups: {
       title: 'Chưa tìm thấy bản sao lưu',
-      description: 'Hãy tạo bản sao lưu cho tài khoản Antigravity IDE hiện tại để bắt đầu.',
+      description: 'Hãy tạo bản sao lưu cho tài khoản Antigravity hiện tại để bắt đầu.',
       action: 'Sao lưu tài khoản hiện tại',
     },
   },
@@ -137,7 +137,7 @@ const vi = {
     modelMapping: {
       title: 'Ánh xạ mô hình',
       description:
-        'Ánh xạ các model Claude Code sang model Antigravity IDE để tối ưu chi phí và tốc độ.',
+        'Ánh xạ các model Claude Code sang model Antigravity để tối ưu chi phí và tốc độ.',
       claudeKeyword: 'Từ khóa model Claude',
       targetGemini: 'Model Gemini đích',
       addPlaceholderKey: 'ví dụ: op-3',
@@ -361,7 +361,7 @@ const vi = {
       pollFailed: 'Không thể polling quota của tất cả tài khoản',
       switched: {
         title: 'Đã chuyển tài khoản!',
-        description: 'Đang khởi động lại Antigravity IDE...',
+        description: 'Đang khởi động lại Antigravity...',
       },
       switchFailed: 'Không thể chuyển tài khoản',
       deleted: 'Đã xóa tài khoản',

--- a/src/localization/vi.ts
+++ b/src/localization/vi.ts
@@ -9,8 +9,8 @@ const vi = {
   },
   status: {
     checking: 'Đang kiểm tra trạng thái...',
-    running: 'Antigravity đang chạy nền',
-    stopped: 'Dịch vụ Antigravity đã dừng',
+    running: 'Antigravity IDE đang chạy nền',
+    stopped: 'Dịch vụ Antigravity IDE đã dừng',
   },
   action: {
     stop: 'Dừng',
@@ -48,10 +48,10 @@ const vi = {
   },
   home: {
     title: 'Tài khoản',
-    description: 'Quản lý các tài khoản Antigravity Google Gemini.',
+    description: 'Quản lý các tài khoản Antigravity IDE Google Gemini.',
     noBackups: {
       title: 'Chưa tìm thấy bản sao lưu',
-      description: 'Hãy tạo bản sao lưu cho tài khoản Antigravity hiện tại để bắt đầu.',
+      description: 'Hãy tạo bản sao lưu cho tài khoản Antigravity IDE hiện tại để bắt đầu.',
       action: 'Sao lưu tài khoản hiện tại',
     },
   },
@@ -137,7 +137,7 @@ const vi = {
     modelMapping: {
       title: 'Ánh xạ mô hình',
       description:
-        'Ánh xạ các model Claude Code sang model Antigravity để tối ưu chi phí và tốc độ.',
+        'Ánh xạ các model Claude Code sang model Antigravity IDE để tối ưu chi phí và tốc độ.',
       claudeKeyword: 'Từ khóa model Claude',
       targetGemini: 'Model Gemini đích',
       addPlaceholderKey: 'ví dụ: op-3',
@@ -361,7 +361,7 @@ const vi = {
       pollFailed: 'Không thể polling quota của tất cả tài khoản',
       switched: {
         title: 'Đã chuyển tài khoản!',
-        description: 'Đang khởi động lại Antigravity...',
+        description: 'Đang khởi động lại Antigravity IDE...',
       },
       switchFailed: 'Không thể chuyển tài khoản',
       deleted: 'Đã xóa tài khoản',

--- a/src/main.ts
+++ b/src/main.ts
@@ -408,19 +408,6 @@ process.on('unhandledRejection', (reason) => {
 app
   .whenReady()
   .then(async () => {
-    logger.info('Step: Initialize CloudAccountRepo');
-    try {
-      await CloudAccountRepo.init();
-    } catch (e) {
-      logger.error('Startup: Failed to initialize CloudAccountRepo', e);
-      // We might want to exit here or show a dialog, but for now we proceed
-      // though functionality will be broken.
-    }
-
-    logger.info('Step: Initialize Antigravity DB (WAL Mode)');
-    initDatabase();
-  })
-  .then(() => {
     logger.info('Step: Load Config');
     const config = ConfigManager.loadConfig();
     startupConfig = config;
@@ -429,6 +416,16 @@ app
     if (shouldStartHidden) {
       logger.info('Startup: Auto-start detected, window will start hidden');
     }
+
+    logger.info('Step: Initialize CloudAccountRepo');
+    try {
+      await CloudAccountRepo.init();
+    } catch (e) {
+      logger.error('Startup: Failed to initialize CloudAccountRepo', e);
+    }
+
+    logger.info('Step: Initialize Antigravity DB (WAL Mode)');
+    initDatabase(config.ideEdition || undefined);
   })
   .then(() => {
     logger.info('Step: setupORPC');

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,7 @@ function showWindowsInstallNoticeIfNeeded() {
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 
 if (isDev) {
-  app.setName('Antigravity Manager Dev');
+  app.setName('Antigravity IDE Manager Dev');
 }
 
 const gotSingleInstanceLock = app.requestSingleInstanceLock();

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,7 @@ function showWindowsInstallNoticeIfNeeded() {
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 
 if (isDev) {
-  app.setName('Antigravity IDE Manager Dev');
+  app.setName('Antigravity Manager Dev');
 }
 
 const gotSingleInstanceLock = app.requestSingleInstanceLock();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,23 +6,12 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 
-// Config check logic (duplicate of instrument.ts logic but adapted for preload)
+// Config check logic - reads from Manager's own data directory
 let sentryEnabled = false;
 try {
   const home = os.homedir();
-  let appDataPath = '';
-  if (process.platform === 'win32') {
-    appDataPath = path.join(
-      process.env.APPDATA || path.join(home, 'AppData', 'Roaming'),
-      'Antigravity',
-    );
-  } else if (process.platform === 'darwin') {
-    appDataPath = path.join(home, 'Library', 'Application Support', 'Antigravity');
-  } else {
-    appDataPath = path.join(home, '.config', 'Antigravity');
-  }
-
-  const configPath = path.join(appDataPath, 'gui_config.json');
+  const managerDataDir = path.join(home, '.antigravity-agent');
+  const configPath = path.join(managerDataDir, 'gui_config.json');
   if (fs.existsSync(configPath)) {
     const content = fs.readFileSync(configPath, 'utf-8');
     const config = JSON.parse(content);

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -23,6 +23,7 @@ import { ModelVisibilitySettings } from '@/components/ModelVisibilitySettings';
 import { useEffect, useState } from 'react';
 import { ProxyConfig } from '@/types/config';
 import { openLogDirectory } from '@/actions/system';
+import type { IdeEdition } from '@/types/config';
 
 function SettingsPage() {
   const { theme, setTheme } = useTheme();
@@ -132,6 +133,31 @@ function SettingsPage() {
                     <SelectItem value="ru">{t('settings.language.russian')}</SelectItem>
                     <SelectItem value="vi">{t('settings.language.vietnamese')}</SelectItem>
                     <SelectItem value="tr">{t('settings.language.turkish')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex items-center justify-between space-x-2">
+                <div className="space-y-1">
+                  <Label htmlFor="ide-edition">{t('settings.ideEdition.title')}</Label>
+                  <p className="text-muted-foreground text-sm">
+                    {t('settings.ideEdition.description')}
+                  </p>
+                </div>
+                <Select
+                  value={config?.ideEdition ?? ''}
+                  onValueChange={async (value: IdeEdition) => {
+                    if (config) {
+                      await saveConfig({ ...config, ideEdition: value });
+                    }
+                  }}
+                >
+                  <SelectTrigger className="w-[180px]">
+                    <SelectValue placeholder={t('settings.ideEdition.placeholder')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1.x">{t('settings.ideEdition.edition1x')}</SelectItem>
+                    <SelectItem value="2.0">{t('settings.ideEdition.edition20')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,6 +27,8 @@ export const ProxyConfigSchema = z.object({
   upstream_proxy: UpstreamProxyConfigSchema,
 });
 
+export type IdeEdition = '1.x' | '2.0';
+
 export const AppConfigSchema = z.object({
   language: z.string(),
   theme: z.string(),
@@ -46,6 +48,7 @@ export const AppConfigSchema = z.object({
     .default('recently-used'),
   quota_alert_enabled: z.boolean().default(false),
   quota_alert_threshold: z.number().default(20),
+  ideEdition: z.enum(['1.x', '2.0']).nullable().default(null),
   proxy: ProxyConfigSchema,
 });
 
@@ -70,6 +73,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   account_sort: 'recently-used' as const,
   quota_alert_enabled: false,
   quota_alert_threshold: 20,
+  ideEdition: null,
   proxy: {
     enabled: false,
     port: 8045,

--- a/src/utils/antigravityVersion.ts
+++ b/src/utils/antigravityVersion.ts
@@ -66,7 +66,7 @@ export function getAntigravityVersion(): AntigravityVersion {
   try {
     const execPath = getAntigravityExecutablePath();
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity executable');
+      throw new Error('Unable to locate Antigravity IDE executable');
     }
 
     if (process.platform === 'win32') {
@@ -144,10 +144,10 @@ export function getAntigravityVersion(): AntigravityVersion {
       }
     }
 
-    throw new Error('Unable to determine Antigravity version');
+    throw new Error('Unable to determine Antigravity IDE version');
   } catch (error) {
     const normalized =
-      error instanceof Error ? error : new Error('Unable to determine Antigravity version');
+      error instanceof Error ? error : new Error('Unable to determine Antigravity IDE version');
     cachedError = normalized;
     throw normalized;
   }

--- a/src/utils/antigravityVersion.ts
+++ b/src/utils/antigravityVersion.ts
@@ -66,7 +66,7 @@ export function getAntigravityVersion(): AntigravityVersion {
   try {
     const execPath = getAntigravityExecutablePath();
     if (!execPath) {
-      throw new Error('Unable to locate Antigravity IDE executable');
+      throw new Error('Unable to locate Antigravity executable');
     }
 
     if (process.platform === 'win32') {
@@ -144,10 +144,10 @@ export function getAntigravityVersion(): AntigravityVersion {
       }
     }
 
-    throw new Error('Unable to determine Antigravity IDE version');
+    throw new Error('Unable to determine Antigravity version');
   } catch (error) {
     const normalized =
-      error instanceof Error ? error : new Error('Unable to determine Antigravity IDE version');
+      error instanceof Error ? error : new Error('Unable to determine Antigravity version');
     cachedError = normalized;
     throw normalized;
   }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 import { execSync } from 'child_process';
+import type { IdeEdition } from '../types/config';
 
 /**
  * Checks if the current platform is WSL.
@@ -269,4 +270,198 @@ export function getAntigravityExecutablePath(): string {
     default:
       return '';
   }
+}
+
+/**
+ * Returns the application name for a given IDE edition.
+ */
+export function getIdeEditionAppName(edition: IdeEdition): string {
+  return edition === '2.0' ? 'Antigravity IDE' : 'Antigravity';
+}
+
+/**
+ * Returns the app data directory for a specific IDE edition.
+ */
+export function getAppDataDirForEdition(edition: IdeEdition): string {
+  const appName = getIdeEditionAppName(edition);
+  const home = os.homedir();
+
+  if (isWsl()) {
+    const winUser = getWindowsUser();
+    return `/mnt/c/Users/${winUser}/AppData/Roaming/${appName}`;
+  }
+
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(home, 'Library', 'Application Support', appName);
+    case 'win32':
+      return path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), appName);
+    case 'linux':
+      return path.join(home, '.config', appName);
+    default:
+      return path.join(home, `.${appName.toLowerCase().replace(/\s+/g, '-')}`);
+  }
+}
+
+/**
+ * Returns the executable path for a specific IDE edition.
+ */
+export function getAntigravityExecutablePathForEdition(edition: IdeEdition): string {
+  const appFolder = edition === '2.0' ? 'Antigravity IDE' : 'Antigravity';
+  const binName = edition === '2.0' ? 'Antigravity IDE' : 'Antigravity';
+
+  if (isWsl()) {
+    const winUser = getWindowsUser();
+    return `/mnt/c/Users/${winUser}/AppData/Local/Programs/${appFolder}/${binName}.exe`;
+  }
+
+  switch (process.platform) {
+    case 'darwin':
+      return `/Applications/${appFolder}.app/Contents/MacOS/${binName}`;
+    case 'win32': {
+      const localAppData = process.env.LOCALAPPDATA || '';
+      const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+      const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+
+      const possiblePaths = [
+        path.join(localAppData, 'Programs', appFolder, `${binName}.exe`),
+        path.join(programFiles, appFolder, `${binName}.exe`),
+        path.join(programFilesX86, appFolder, `${binName}.exe`),
+      ];
+
+      for (const p of possiblePaths) {
+        if (fs.existsSync(p)) {
+          return p;
+        }
+      }
+
+      return '';
+    }
+    case 'linux': {
+      const binLower = binName.toLowerCase().replace(/\s+/g, '-');
+      const possibleLinuxPaths = [
+        `/usr/bin/${binLower}`,
+        `/usr/local/bin/${binLower}`,
+        `/usr/share/${binLower}/${binLower}`,
+        `/opt/${appFolder}/${binLower}`,
+        `/opt/${binLower}/${binLower}`,
+        path.join(os.homedir(), '.local', 'share', binLower, binLower),
+      ];
+
+      for (const p of possibleLinuxPaths) {
+        if (fs.existsSync(p)) {
+          return p;
+        }
+      }
+
+      const fromPath = process.env.PATH?.split(':')
+        .map((dir) => path.join(dir, binLower))
+        .find((p) => fs.existsSync(p));
+      if (fromPath) {
+        return fromPath;
+      }
+
+      return '';
+    }
+    default:
+      return '';
+  }
+}
+
+/**
+ * Returns database paths for a specific IDE edition.
+ */
+export function getAntigravityDbPathsForEdition(edition: IdeEdition): string[] {
+  const appData = getAppDataDirForEdition(edition);
+  const paths: string[] = [];
+  const home = os.homedir();
+
+  if (isWsl()) {
+    paths.push(path.join(appData, 'User', 'globalStorage', 'state.vscdb'));
+    paths.push(path.join(appData, 'User', 'state.vscdb'));
+    paths.push(path.join(appData, 'state.vscdb'));
+    return paths;
+  }
+
+  if (process.platform === 'linux') {
+    paths.push(path.join(appData, 'User', 'globalStorage', 'state.vscdb'));
+    paths.push(path.join(appData, 'User', 'state.vscdb'));
+    paths.push(path.join(appData, 'state.vscdb'));
+    return paths;
+  }
+
+  if (process.platform === 'darwin') {
+    const appName = getIdeEditionAppName(edition);
+    paths.push(
+      path.join(
+        home,
+        'Library',
+        'Application Support',
+        appName,
+        'User',
+        'globalStorage',
+        'state.vscdb',
+      ),
+    );
+    paths.push(path.join(home, 'Library', 'Application Support', appName, 'state.vscdb'));
+    return paths;
+  }
+
+  paths.push(path.join(appData, 'User', 'globalStorage', 'state.vscdb'));
+  paths.push(path.join(appData, 'User', 'state.vscdb'));
+  paths.push(path.join(appData, 'state.vscdb'));
+
+  return paths;
+}
+
+/**
+ * Returns storage.json paths for a specific IDE edition.
+ */
+export function getAntigravityStoragePathsForEdition(edition: IdeEdition): string[] {
+  const appData = getAppDataDirForEdition(edition);
+  const paths: string[] = [];
+  const home = os.homedir();
+
+  if (isWsl()) {
+    paths.push(path.join(appData, 'User', 'globalStorage', 'storage.json'));
+    paths.push(path.join(appData, 'User', 'storage.json'));
+    paths.push(path.join(appData, 'storage.json'));
+    return paths;
+  }
+
+  if (process.platform === 'linux') {
+    paths.push(path.join(appData, 'User', 'globalStorage', 'storage.json'));
+    paths.push(path.join(appData, 'User', 'storage.json'));
+    paths.push(path.join(appData, 'storage.json'));
+    return paths;
+  }
+
+  if (process.platform === 'darwin') {
+    const appName = getIdeEditionAppName(edition);
+    paths.push(
+      path.join(
+        home,
+        'Library',
+        'Application Support',
+        appName,
+        'User',
+        'globalStorage',
+        'storage.json',
+      ),
+    );
+    paths.push(path.join(home, 'Library', 'Application Support', appName, 'storage.json'));
+    return paths;
+  }
+
+  paths.push(path.join(appData, 'User', 'globalStorage', 'storage.json'));
+  paths.push(path.join(appData, 'User', 'storage.json'));
+  paths.push(path.join(appData, 'storage.json'));
+  return paths;
+}
+
+/**
+ * Returns the URI protocol for a specific IDE edition.
+ */
+export function getIdeEditionUriProtocol(edition: IdeEdition): string {
+  return edition === '2.0' ? 'antigravity-ide' : 'antigravity';
 }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -78,18 +78,18 @@ export function getAppDataDir(): string {
 
   if (isWsl()) {
     const winUser = getWindowsUser();
-    return `/mnt/c/Users/${winUser}/AppData/Roaming/Antigravity`;
+    return `/mnt/c/Users/${winUser}/AppData/Roaming/Antigravity IDE`;
   }
 
   switch (process.platform) {
     case 'darwin':
-      return path.join(home, 'Library', 'Application Support', 'Antigravity');
+      return path.join(home, 'Library', 'Application Support', 'Antigravity IDE');
     case 'win32':
-      return path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'Antigravity');
+      return path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'Antigravity IDE');
     case 'linux':
-      return path.join(home, '.config', 'Antigravity');
+      return path.join(home, '.config', 'Antigravity IDE');
     default:
-      return path.join(home, '.antigravity');
+      return path.join(home, '.antigravity-ide');
   }
 }
 
@@ -137,14 +137,14 @@ export function getAntigravityDbPaths(): string[] {
         home,
         'Library',
         'Application Support',
-        'Antigravity',
+        'Antigravity IDE',
         'User',
         'globalStorage',
         'state.vscdb',
       ),
     );
     // Fallback path
-    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity', 'state.vscdb'));
+    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity IDE', 'state.vscdb'));
     return paths;
   }
 
@@ -183,13 +183,13 @@ export function getAntigravityStoragePaths(): string[] {
         home,
         'Library',
         'Application Support',
-        'Antigravity',
+        'Antigravity IDE',
         'User',
         'globalStorage',
         'storage.json',
       ),
     );
-    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity', 'storage.json'));
+    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity IDE', 'storage.json'));
     return paths;
   }
 
@@ -213,21 +213,21 @@ export function getAntigravityDbPath(): string {
 export function getAntigravityExecutablePath(): string {
   if (isWsl()) {
     const winUser = getWindowsUser();
-    return `/mnt/c/Users/${winUser}/AppData/Local/Programs/Antigravity/Antigravity.exe`;
+    return `/mnt/c/Users/${winUser}/AppData/Local/Programs/Antigravity IDE/Antigravity IDE.exe`;
   }
 
   switch (process.platform) {
     case 'darwin':
-      return '/Applications/Antigravity.app/Contents/MacOS/Antigravity';
+      return '/Applications/Antigravity IDE.app/Contents/MacOS/Antigravity IDE';
     case 'win32': {
       const localAppData = process.env.LOCALAPPDATA || '';
       const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
       const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
 
       const possiblePaths = [
-        path.join(localAppData, 'Programs', 'Antigravity', 'Antigravity.exe'),
-        path.join(programFiles, 'Antigravity', 'Antigravity.exe'),
-        path.join(programFilesX86, 'Antigravity', 'Antigravity.exe'),
+        path.join(localAppData, 'Programs', 'Antigravity IDE', 'Antigravity IDE.exe'),
+        path.join(programFiles, 'Antigravity IDE', 'Antigravity IDE.exe'),
+        path.join(programFilesX86, 'Antigravity IDE', 'Antigravity IDE.exe'),
       ];
 
       for (const p of possiblePaths) {
@@ -241,12 +241,12 @@ export function getAntigravityExecutablePath(): string {
     }
     case 'linux': {
       const possibleLinuxPaths = [
-        '/usr/bin/antigravity',
-        '/usr/local/bin/antigravity',
-        '/usr/share/antigravity/antigravity',
-        '/opt/Antigravity/antigravity',
-        '/opt/antigravity/antigravity',
-        path.join(os.homedir(), '.local', 'share', 'antigravity', 'antigravity'),
+        '/usr/bin/antigravity-ide',
+        '/usr/local/bin/antigravity-ide',
+        '/usr/share/antigravity-ide/antigravity-ide',
+        '/opt/Antigravity IDE/antigravity-ide',
+        '/opt/antigravity-ide/antigravity-ide',
+        path.join(os.homedir(), '.local', 'share', 'antigravity-ide', 'antigravity-ide'),
       ];
 
       for (const p of possibleLinuxPaths) {
@@ -255,9 +255,9 @@ export function getAntigravityExecutablePath(): string {
         }
       }
 
-      // Fallback: try `which antigravity` via path lookup
+      // Fallback: try `which antigravity-ide` via path lookup
       const fromPath = process.env.PATH?.split(':')
-        .map((dir) => path.join(dir, 'antigravity'))
+        .map((dir) => path.join(dir, 'antigravity-ide'))
         .find((p) => fs.existsSync(p));
       if (fromPath) {
         return fromPath;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -78,18 +78,18 @@ export function getAppDataDir(): string {
 
   if (isWsl()) {
     const winUser = getWindowsUser();
-    return `/mnt/c/Users/${winUser}/AppData/Roaming/Antigravity IDE`;
+    return `/mnt/c/Users/${winUser}/AppData/Roaming/Antigravity`;
   }
 
   switch (process.platform) {
     case 'darwin':
-      return path.join(home, 'Library', 'Application Support', 'Antigravity IDE');
+      return path.join(home, 'Library', 'Application Support', 'Antigravity');
     case 'win32':
-      return path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'Antigravity IDE');
+      return path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'Antigravity');
     case 'linux':
-      return path.join(home, '.config', 'Antigravity IDE');
+      return path.join(home, '.config', 'Antigravity');
     default:
-      return path.join(home, '.antigravity-ide');
+      return path.join(home, '.antigravity');
   }
 }
 
@@ -137,14 +137,14 @@ export function getAntigravityDbPaths(): string[] {
         home,
         'Library',
         'Application Support',
-        'Antigravity IDE',
+        'Antigravity',
         'User',
         'globalStorage',
         'state.vscdb',
       ),
     );
     // Fallback path
-    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity IDE', 'state.vscdb'));
+    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity', 'state.vscdb'));
     return paths;
   }
 
@@ -183,13 +183,13 @@ export function getAntigravityStoragePaths(): string[] {
         home,
         'Library',
         'Application Support',
-        'Antigravity IDE',
+        'Antigravity',
         'User',
         'globalStorage',
         'storage.json',
       ),
     );
-    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity IDE', 'storage.json'));
+    paths.push(path.join(home, 'Library', 'Application Support', 'Antigravity', 'storage.json'));
     return paths;
   }
 
@@ -213,21 +213,21 @@ export function getAntigravityDbPath(): string {
 export function getAntigravityExecutablePath(): string {
   if (isWsl()) {
     const winUser = getWindowsUser();
-    return `/mnt/c/Users/${winUser}/AppData/Local/Programs/Antigravity IDE/Antigravity IDE.exe`;
+    return `/mnt/c/Users/${winUser}/AppData/Local/Programs/Antigravity/Antigravity.exe`;
   }
 
   switch (process.platform) {
     case 'darwin':
-      return '/Applications/Antigravity IDE.app/Contents/MacOS/Antigravity IDE';
+      return '/Applications/Antigravity.app/Contents/MacOS/Antigravity';
     case 'win32': {
       const localAppData = process.env.LOCALAPPDATA || '';
       const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
       const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
 
       const possiblePaths = [
-        path.join(localAppData, 'Programs', 'Antigravity IDE', 'Antigravity IDE.exe'),
-        path.join(programFiles, 'Antigravity IDE', 'Antigravity IDE.exe'),
-        path.join(programFilesX86, 'Antigravity IDE', 'Antigravity IDE.exe'),
+        path.join(localAppData, 'Programs', 'Antigravity', 'Antigravity.exe'),
+        path.join(programFiles, 'Antigravity', 'Antigravity.exe'),
+        path.join(programFilesX86, 'Antigravity', 'Antigravity.exe'),
       ];
 
       for (const p of possiblePaths) {
@@ -241,12 +241,12 @@ export function getAntigravityExecutablePath(): string {
     }
     case 'linux': {
       const possibleLinuxPaths = [
-        '/usr/bin/antigravity-ide',
-        '/usr/local/bin/antigravity-ide',
-        '/usr/share/antigravity-ide/antigravity-ide',
-        '/opt/Antigravity IDE/antigravity-ide',
-        '/opt/antigravity-ide/antigravity-ide',
-        path.join(os.homedir(), '.local', 'share', 'antigravity-ide', 'antigravity-ide'),
+        '/usr/bin/antigravity',
+        '/usr/local/bin/antigravity',
+        '/usr/share/antigravity/antigravity',
+        '/opt/Antigravity/antigravity',
+        '/opt/antigravity/antigravity',
+        path.join(os.homedir(), '.local', 'share', 'antigravity', 'antigravity'),
       ];
 
       for (const p of possibleLinuxPaths) {
@@ -255,9 +255,9 @@ export function getAntigravityExecutablePath(): string {
         }
       }
 
-      // Fallback: try `which antigravity-ide` via path lookup
+      // Fallback: try `which antigravity` via path lookup
       const fromPath = process.env.PATH?.split(':')
-        .map((dir) => path.join(dir, 'antigravity-ide'))
+        .map((dir) => path.join(dir, 'antigravity'))
         .find((p) => fs.existsSync(p));
       if (fromPath) {
         return fromPath;


### PR DESCRIPTION
Update all paths, process detection, and UI references to target Antigravity IDE instead of the legacy Antigravity app.

- Update executable paths for macOS, Windows, and Linux
- Update AppData/storage directories to Antigravity IDE
- Update process detection to match Antigravity IDE processes
- Update URI protocol to antigravity-ide://
- Update i18n strings (en, zh-CN, ru, vi, tr)
- Update sidebar title to Antigravity IDE