### PR TITLE
fix(proxy): resolve 400 Bad Request for gemini-3.1-pro-high model

### DIFF
--- a/src/modules/proxy-gateway/antigravity/model-specs.json
+++ b/src/modules/proxy-gateway/antigravity/model-specs.json
@@ -12,7 +12,7 @@
     },
     "gemini-3.1-pro-high": {
       "max_output_tokens": 65536,
-      "thinking_budget": 49152,
+      "thinking_budget": 32768,
       "is_thinking": true
     },
     "gemini-3-pro-image": {

--- a/src/modules/proxy-gateway/server/token-manager.service.ts
+++ b/src/modules/proxy-gateway/server/token-manager.service.ts
@@ -1119,8 +1119,17 @@ export class TokenManagerService implements OnModuleInit {
       }
     };
 
-    // Keep requested model first, then fallback across the same family.
-    pushCandidate(normalizedModel);
+    // When the requested model is gemini-3.1-pro-high or gemini-3.1-pro,
+    // prioritize gemini-3.1-pro-preview as the first candidate. The upstream
+    // API rejects the '-high' suffix with 400 INVALID_ARGUMENT.
+    if (normalizedModel === 'gemini-3.1-pro-high' || normalizedModel === 'gemini-3.1-pro') {
+      pushCandidate('gemini-3.1-pro-preview');
+      pushCandidate('gemini-3.1-pro');
+      pushCandidate(normalizedModel);
+    } else {
+      pushCandidate(normalizedModel);
+    }
+
     pushCandidate('gemini-3.1-pro-preview');
     pushCandidate('gemini-3-pro-preview');
     pushCandidate('gemini-3.1-pro-high');


### PR DESCRIPTION
## Summary

The upstream Google API rejects `gemini-3.1-pro-high` as a model name with `400 INVALID_ARGUMENT`, causing all requests using the high-tier Gemini Pro model to fail.

### Changes

**`src/modules/proxy-gateway/antigravity/model-specs.json`**
- Reduce `thinking_budget` for `gemini-3.1-pro-high` from `49152` to `32768` to match the API's accepted maximum. Values above 32768 trigger a 400 error.

**`src/modules/proxy-gateway/server/token-manager.service.ts`**
- In `buildDynamicModelCandidates()`, prioritize `gemini-3.1-pro-preview` as the first fallback candidate when `gemini-3.1-pro-high` or `gemini-3.1-pro` is requested.
- The upstream API accepts `-preview` but rejects `-high`, so this ensures requests succeed on the first attempt.
- The existing deduplication logic (`seen` set) ensures no model name is tried twice in the fallback sequence.

### Testing
- Verified that requests using `gemini-3.1-pro-high` model no longer return 400 errors.
- The `-preview` variant is functionally equivalent and accepted by the upstream API.