### PR TITLE
Fix(auto-switch): Not working for Antigravity IDE due to missing appTarget propagation

### DIFF
--- a/src/modules/cloud-account/services/AutoSwitchService.ts
+++ b/src/modules/cloud-account/services/AutoSwitchService.ts
@@ -2,6 +2,7 @@ import { CloudAccountRepo } from '@/modules/cloud-account/persistence/cloudHandl
 import { CloudAccount } from '@/modules/cloud-account/types';
 import { switchCloudAccount } from '@/modules/cloud-account/ipc/handler';
 import { logger } from '@/shared/logging/logger';
+import { AntigravityAppTarget } from '@/modules/account/types';
 
 export class AutoSwitchService {
   /**
@@ -57,13 +58,16 @@ export class AutoSwitchService {
    * Triggered by Monitor Service or UI.
    * Checks if we need to switch from the current account.
    */
-  static async checkAndSwitchIfNeeded(): Promise<boolean> {
+  static async checkAndSwitchIfNeeded(appTarget?: AntigravityAppTarget | undefined): Promise<boolean> {
     const enabled = CloudAccountRepo.getSetting<boolean>('auto_switch_enabled', false);
     if (!enabled) return false;
 
-    // Get current active account
+    // Get current active account for the target
     const accounts = await CloudAccountRepo.getAccounts();
-    const currentAccount = accounts.find((a) => a.is_active);
+    const activeAccountId = CloudAccountRepo.getActiveAccountIdForTarget(appTarget);
+    const currentAccount = activeAccountId
+      ? accounts.find((a) => a.id === activeAccountId)
+      : accounts.find((a) => a.is_active);
 
     // If no active account, maybe we should pick one?
     // For now, assume user manually picked first one.
@@ -85,7 +89,7 @@ export class AutoSwitchService {
         // Ideally we send an IPC event to renderer.
         // For now, logic first.
 
-        await switchCloudAccount(nextAccount.id);
+        await switchCloudAccount(nextAccount.id, appTarget);
 
         // We might want to send a notification to user desktop?
         // require('electron').Notification ...

--- a/src/modules/cloud-account/services/CloudMonitorService.ts
+++ b/src/modules/cloud-account/services/CloudMonitorService.ts
@@ -5,6 +5,7 @@ import { AutoSwitchService } from './AutoSwitchService';
 import { logger } from '@/shared/logging/logger';
 import { classifyAccountStatusFromError } from '@/modules/cloud-account/utils/account-status';
 import type { CloudAccount } from '@/modules/cloud-account/types';
+import { AntigravityAppTargetSchema } from '@/modules/account/types';
 
 type CloudMonitorLanguage = 'en' | 'zh-CN' | 'ru' | 'vi';
 
@@ -264,7 +265,9 @@ export class CloudMonitorService {
       }
 
       // 5. Check for Auto-Switch
-      await AutoSwitchService.checkAndSwitchIfNeeded();
+      for (const target of AntigravityAppTargetSchema.options) {
+        await AutoSwitchService.checkAndSwitchIfNeeded(target);
+      }
     } finally {
       this.isPolling = false;
     }


### PR DESCRIPTION
#### Problem

When using Antigravity IDE, cloud accounts were not automatically switched after quota depletion.

After tracing the auto-switch flow, I found that `CloudMonitorService` calls:

```ts
await AutoSwitchService.checkAndSwitchIfNeeded();
```

without passing an `appTarget`.

As a result:

```ts
resolveAntigravityAppTarget(undefined)
```

falls back to:

```ts
'classic'
```

which causes the auto-switch logic to inspect and update the active account for the Classic client instead of the IDE client.

This means:

* Auto-switch works for Classic.
* Auto-switch may fail or behave incorrectly for IDE.
* IDE active-account state is ignored because the target context is lost.

#### Fix

1. Iterate through all supported targets from `AntigravityAppTargetSchema.options` inside `CloudMonitorService`.

```ts
for (const target of AntigravityAppTargetSchema.options) {
  await AutoSwitchService.checkAndSwitchIfNeeded(target);
}
```

2. Update `AutoSwitchService.checkAndSwitchIfNeeded()` to resolve the active account using:

```ts
CloudAccountRepo.getActiveAccountIdForTarget(appTarget)
```

instead of relying on the global `is_active` flag.

3. Propagate `appTarget` when performing the actual account switch:

```ts
await switchCloudAccount(nextAccount.id, appTarget);
```

#### Result

* Auto-switch now works correctly for both Classic and IDE.
* Each target maintains its own active-account context.
* The monitor no longer defaults to Classic when checking IDE accounts.

#### Reproduction

1. Configure different active accounts for Classic and IDE.
2. Deplete the quota of the IDE account.
3. Trigger CloudMonitor polling.
4. Before this fix, no IDE switch occurs (or the wrong account context is used).
5. After this fix, IDE correctly switches to the next available account.
