### PR TITLE
chore(nix): update flake to v0.18.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,16 +12,16 @@
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
     forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-    version = "0.17.1";
+    version = "0.18.0";
 
     sources = {
       "x86_64-linux" = {
         url = "https://github.com/Draculabo/AntigravityManager/releases/download/v${version}/Antigravity.Manager_${version}_amd64.deb";
-        sha256 = "e70d2730d50e851e276c8c51c88dbc19e2d2d14f6ee70c1147f1719b38aad73e";
+        sha256 = "5755282843b78dd2fceefcaff2fdddb523f50c9006309bd7884cc956723d34e8";
       };
       "aarch64-linux" = {
         url = "https://github.com/Draculabo/AntigravityManager/releases/download/v${version}/Antigravity.Manager_${version}_arm64.deb";
-        sha256 = "1e44d9d3cbee3ca4174342d75be46d68ff736037ca9ba5fcf4e04a68b104db3a";
+        sha256 = "c02c93ef171b7a37ea8c2b91e3f0c1f2b02dfbf6d9d6f026b6efd5743ad346ef";
       };
     };
 


### PR DESCRIPTION
Update `flake.nix` to match `v0.18.0` release assets.

The hashes come from the Linux checksum files generated during the release build.