### PR TITLE
fix: opt-in GPU-safe Chromium switches to stop Windows white-screen-then-close startup crash

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import {
   isRunningFromExpectedInstallDir as isRunningFromExpectedInstallDirUtil,
   resolveInstallNoticeLanguage,
 } from './modules/app-shell/utils/installNotice';
+import { applyStartupGpuSwitches } from '@/modules/app-shell/utils/startupGpuSwitches';
 import { CloudAccountRepo } from '@/modules/cloud-account/persistence/cloudHandler';
 import { initDatabase } from '@/shared/persistence/database/handler';
 import { CloudMonitorService } from '@/modules/cloud-account/services/CloudMonitorService';
@@ -60,11 +61,13 @@ ipcMain.on(IPC_CHANNELS.CHANGE_LANGUAGE, (event, lang) => {
   setTrayLanguage(lang);
 });
 
-if (process.platform === 'linux') {
-  app.disableHardwareAcceleration();
-  app.commandLine.appendSwitch('disable-gpu');
-  app.commandLine.appendSwitch('disable-gpu-compositing');
-  logger.info('Applied Linux GPU-safe Chromium switches for Antigravity Manager startup');
+const gpuSwitchResult = applyStartupGpuSwitches(app, process.platform, process.env);
+if (gpuSwitchResult.disabledHardwareAcceleration || gpuSwitchResult.appliedSwitches.length > 0) {
+  logger.info(
+    `Applied GPU-safe Chromium startup switches for ${process.platform}: ` +
+      `hardwareAccelerationDisabled=${gpuSwitchResult.disabledHardwareAcceleration}, ` +
+      `switches=[${gpuSwitchResult.appliedSwitches.join(', ')}]`,
+  );
 }
 
 if (squirrelStartup) {

--- a/src/modules/app-shell/utils/startupGpuSwitches.ts
+++ b/src/modules/app-shell/utils/startupGpuSwitches.ts
@@ -1,0 +1,68 @@
+export interface StartupGpuSwitchTarget {
+  disableHardwareAcceleration: () => void;
+  commandLine: { appendSwitch: (switch_: string, value?: string) => void };
+}
+
+export interface ApplyStartupGpuSwitchesResult {
+  disabledHardwareAcceleration: boolean;
+  appliedSwitches: string[];
+}
+
+const isFullGpuDisableEnabled = (env: NodeJS.ProcessEnv) => {
+  const value = env.ANTIGRAVITY_DISABLE_GPU?.toLowerCase();
+
+  return value === '1' || value === 'true';
+};
+
+/**
+ * Applies platform-conditional GPU-safe Chromium switches at Electron startup.
+ *
+ * - linux: unchanged historical behavior - disable hardware acceleration plus
+ *   `disable-gpu` and `disable-gpu-compositing`.
+ * - win32: opt-in fallback for the white-screen-then-close GPU-process crash.
+ *     - default (no env flag): apply only the safe `disable-gpu-compositing`
+ *       switch; hardware acceleration stays ON.
+ *     - `ANTIGRAVITY_DISABLE_GPU=1` (or "true"): fully disable the GPU -
+ *       disableHardwareAcceleration() plus `disable-gpu` and
+ *       `disable-gpu-compositing`.
+ * - all other platforms (darwin etc.): apply nothing (no regression).
+ */
+export function applyStartupGpuSwitches(
+  target: StartupGpuSwitchTarget,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): ApplyStartupGpuSwitchesResult {
+  const result: ApplyStartupGpuSwitchesResult = {
+    disabledHardwareAcceleration: false,
+    appliedSwitches: [],
+  };
+
+  const disableHardwareAcceleration = () => {
+    target.disableHardwareAcceleration();
+    result.disabledHardwareAcceleration = true;
+  };
+
+  const appendSwitch = (switch_: string) => {
+    target.commandLine.appendSwitch(switch_);
+    result.appliedSwitches.push(switch_);
+  };
+
+  if (platform === 'linux') {
+    disableHardwareAcceleration();
+    appendSwitch('disable-gpu');
+    appendSwitch('disable-gpu-compositing');
+
+    return result;
+  }
+
+  if (platform === 'win32') {
+    if (isFullGpuDisableEnabled(env)) {
+      disableHardwareAcceleration();
+      appendSwitch('disable-gpu');
+    }
+
+    appendSwitch('disable-gpu-compositing');
+  }
+
+  return result;
+}

--- a/src/modules/app-shell/utils/startupGpuSwitches.ts
+++ b/src/modules/app-shell/utils/startupGpuSwitches.ts
@@ -20,8 +20,8 @@ const isFullGpuDisableEnabled = (env: NodeJS.ProcessEnv) => {
  * - linux: unchanged historical behavior - disable hardware acceleration plus
  *   `disable-gpu` and `disable-gpu-compositing`.
  * - win32: opt-in fallback for the white-screen-then-close GPU-process crash.
- *     - default (no env flag): apply only the safe `disable-gpu-compositing`
- *       switch; hardware acceleration stays ON.
+ *     - default (no env flag): apply nothing; hardware acceleration stays ON
+ *       so users who are not affected keep normal rendering.
  *     - `ANTIGRAVITY_DISABLE_GPU=1` (or "true"): fully disable the GPU -
  *       disableHardwareAcceleration() plus `disable-gpu` and
  *       `disable-gpu-compositing`.
@@ -56,12 +56,16 @@ export function applyStartupGpuSwitches(
   }
 
   if (platform === 'win32') {
+    // Windows GPU intervention is strictly opt-in: only when the user sets
+    // ANTIGRAVITY_DISABLE_GPU do we change startup behavior, so unaffected
+    // users keep full hardware acceleration. This mirrors the maintainer's
+    // request for a fallback that does not force --no-sandbox or a forced
+    // software-compositing path on every Windows launch.
     if (isFullGpuDisableEnabled(env)) {
       disableHardwareAcceleration();
       appendSwitch('disable-gpu');
+      appendSwitch('disable-gpu-compositing');
     }
-
-    appendSwitch('disable-gpu-compositing');
   }
 
   return result;

--- a/src/tests/unit/browser-window-security.test.ts
+++ b/src/tests/unit/browser-window-security.test.ts
@@ -22,9 +22,16 @@ describe('BrowserWindow security settings', () => {
 
   it('does not use no-sandbox or Windows GPU startup switches as the compatibility fix', () => {
     const mainSource = readFileSync(path.join(process.cwd(), 'src/main.ts'), 'utf-8');
+    const gpuSwitchesSource = readFileSync(
+      path.join(process.cwd(), 'src/modules/app-shell/utils/startupGpuSwitches.ts'),
+      'utf-8',
+    );
 
-    expect(mainSource).toContain("if (process.platform === 'linux')");
+    expect(mainSource).toContain('applyStartupGpuSwitches');
+    expect(gpuSwitchesSource).toContain("if (platform === 'linux')");
     expect(mainSource).not.toContain("app.commandLine.appendSwitch('no-sandbox')");
-    expect(mainSource).not.toMatch(/process\.platform === 'linux' \|\| process\.platform === 'win32'/);
+    expect(mainSource).not.toMatch(
+      /process\.platform === 'linux' \|\| process\.platform === 'win32'/,
+    );
   });
 });

--- a/src/tests/unit/startupGpuSwitches.test.ts
+++ b/src/tests/unit/startupGpuSwitches.test.ts
@@ -49,18 +49,15 @@ describe('applyStartupGpuSwitches', () => {
     expect(result.appliedSwitches).toEqual(['disable-gpu', 'disable-gpu-compositing']);
   });
 
-  it('keeps Windows hardware acceleration on by default while disabling GPU compositing', () => {
+  it('applies no startup GPU switches on Windows by default', () => {
     const target = createTarget();
 
     const result = applyStartupGpuSwitches(target, 'win32', {});
 
     expect(target.disableHardwareAcceleration).not.toHaveBeenCalled();
-    expect(target.commandLine.appendSwitch).toHaveBeenCalledOnce();
-    expect(target.commandLine.appendSwitch).toHaveBeenCalledWith(
-      'disable-gpu-compositing',
-    );
+    expect(target.commandLine.appendSwitch).not.toHaveBeenCalled();
     expect(result.disabledHardwareAcceleration).toBe(false);
-    expect(result.appliedSwitches).toEqual(['disable-gpu-compositing']);
+    expect(result.appliedSwitches).toEqual([]);
   });
 
   it('fully disables Windows GPU startup when ANTIGRAVITY_DISABLE_GPU is true', () => {

--- a/src/tests/unit/startupGpuSwitches.test.ts
+++ b/src/tests/unit/startupGpuSwitches.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applyStartupGpuSwitches,
+  type StartupGpuSwitchTarget,
+} from '@/modules/app-shell/utils/startupGpuSwitches';
+
+function createTarget() {
+  const target: StartupGpuSwitchTarget = {
+    disableHardwareAcceleration: vi.fn(),
+    commandLine: {
+      appendSwitch: vi.fn(),
+    },
+  };
+
+  return target;
+}
+
+describe('applyStartupGpuSwitches', () => {
+  it('applies historical Linux GPU-safe startup switches', () => {
+    const target = createTarget();
+
+    const result = applyStartupGpuSwitches(target, 'linux', {});
+
+    expect(target.disableHardwareAcceleration).toHaveBeenCalledOnce();
+    expect(target.commandLine.appendSwitch).toHaveBeenNthCalledWith(1, 'disable-gpu');
+    expect(target.commandLine.appendSwitch).toHaveBeenNthCalledWith(
+      2,
+      'disable-gpu-compositing',
+    );
+    expect(result.disabledHardwareAcceleration).toBe(true);
+    expect(result.appliedSwitches).toEqual(['disable-gpu', 'disable-gpu-compositing']);
+  });
+
+  it('fully disables Windows GPU startup when ANTIGRAVITY_DISABLE_GPU is 1', () => {
+    const target = createTarget();
+
+    const result = applyStartupGpuSwitches(target, 'win32', {
+      ANTIGRAVITY_DISABLE_GPU: '1',
+    });
+
+    expect(target.disableHardwareAcceleration).toHaveBeenCalledOnce();
+    expect(target.commandLine.appendSwitch).toHaveBeenNthCalledWith(1, 'disable-gpu');
+    expect(target.commandLine.appendSwitch).toHaveBeenNthCalledWith(
+      2,
+      'disable-gpu-compositing',
+    );
+    expect(result.disabledHardwareAcceleration).toBe(true);
+    expect(result.appliedSwitches).toEqual(['disable-gpu', 'disable-gpu-compositing']);
+  });
+
+  it('keeps Windows hardware acceleration on by default while disabling GPU compositing', () => {
+    const target = createTarget();
+
+    const result = applyStartupGpuSwitches(target, 'win32', {});
+
+    expect(target.disableHardwareAcceleration).not.toHaveBeenCalled();
+    expect(target.commandLine.appendSwitch).toHaveBeenCalledOnce();
+    expect(target.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'disable-gpu-compositing',
+    );
+    expect(result.disabledHardwareAcceleration).toBe(false);
+    expect(result.appliedSwitches).toEqual(['disable-gpu-compositing']);
+  });
+
+  it('fully disables Windows GPU startup when ANTIGRAVITY_DISABLE_GPU is true', () => {
+    const target = createTarget();
+
+    const result = applyStartupGpuSwitches(target, 'win32', {
+      ANTIGRAVITY_DISABLE_GPU: 'true',
+    });
+
+    expect(target.disableHardwareAcceleration).toHaveBeenCalledOnce();
+    expect(target.commandLine.appendSwitch).toHaveBeenNthCalledWith(1, 'disable-gpu');
+    expect(target.commandLine.appendSwitch).toHaveBeenNthCalledWith(
+      2,
+      'disable-gpu-compositing',
+    );
+    expect(result.disabledHardwareAcceleration).toBe(true);
+    expect(result.appliedSwitches).toEqual(['disable-gpu', 'disable-gpu-compositing']);
+  });
+
+  it('does not apply startup GPU switches on macOS', () => {
+    const target = createTarget();
+
+    const result = applyStartupGpuSwitches(target, 'darwin', {});
+
+    expect(target.disableHardwareAcceleration).not.toHaveBeenCalled();
+    expect(target.commandLine.appendSwitch).not.toHaveBeenCalled();
+    expect(result.disabledHardwareAcceleration).toBe(false);
+    expect(result.appliedSwitches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a strictly opt-in, GPU-safe Chromium startup fallback for Windows so users hitting the white-screen-then-close crash can recover, while extracting the existing Linux GPU handling into a small, unit-tested pure helper.

## Background

On Windows 11 the app opens, shows a white window for a few seconds, then closes on startup (#202). A second reporter on an AMD RX 6600 reproduced it consistently, and the symptom matches a classic GPU-process initialization failure on certain Windows GPU/driver combinations. In the issue thread the maintainer pointed at Electron renderer sandboxing / GPU initialization / Sentry GPU-context collection, and asked for a product-side fix that does **not** force users to launch with `--no-sandbox`.

`src/main.ts` already applied GPU-safe Chromium switches for Linux but nothing for Windows, so affected Windows users had no in-product escape hatch short of editing packaged files.

## Changes

Extract the platform-conditional switch logic into a pure helper, `applyStartupGpuSwitches(target, platform, env)`, in `src/modules/app-shell/utils/startupGpuSwitches.ts`, and add a Windows branch:

- **Linux** — unchanged: `disableHardwareAcceleration()` + `disable-gpu` + `disable-gpu-compositing`.
- **Windows, default** — no switches applied; hardware acceleration stays on, so users who are not hitting the crash see no behavior change.
- **Windows with `ANTIGRAVITY_DISABLE_GPU=1`** (or `true`) — fully disables the GPU: `disableHardwareAcceleration()` + `disable-gpu` + `disable-gpu-compositing`. This is the escape hatch for affected users, without editing any packaged files.
- **macOS / other** — no switches (no regression to the working path).

`main.ts` calls the helper at the same startup point the inline Linux block ran before, and logs which switches were applied. Sentry's GPU-context integration filtering is untouched.

The Windows path is intentionally opt-in: the maintainer wanted to avoid forcing a change on users who do not hit the crash. Affected users set one environment variable; everyone else keeps full hardware acceleration.

## Testing

New `src/tests/unit/startupGpuSwitches.test.ts` covers Linux, Windows opt-in (`1` and `true`), Windows default no-op, and macOS no-op. The existing `browser-window-security.test.ts` source-grep test is updated to follow the refactor while keeping its `no-sandbox` / no-blanket-win32-GPU guarantees.

Fixes #202
