### PR TITLE
chore(nix): update flake to v0.19.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,16 +12,16 @@
     supportedSystems = ["x86_64-linux" "aarch64-linux"];
     forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-    version = "0.18.1";
+    version = "0.19.0";
 
     sources = {
       "x86_64-linux" = {
         url = "https://github.com/Draculabo/AntigravityManager/releases/download/v${version}/Antigravity.Manager_${version}_amd64.deb";
-        sha256 = "22cc1049cb5e6969c672842da61ff9760e361bd2787fbe7a20964f5f86fef4dd";
+        sha256 = "337b7a21796c1d97660d195296723781adf2daee882e265b4c4d00b1a5194761";
       };
       "aarch64-linux" = {
         url = "https://github.com/Draculabo/AntigravityManager/releases/download/v${version}/Antigravity.Manager_${version}_arm64.deb";
-        sha256 = "02d615bfd6bf99dd620a9a9eb2edb2e79b65e24f7676c94e60f0a8aea00bcc21";
+        sha256 = "3f1d6afc8a833b452720fd775c19f5341db0c9a3a9e6e244bbc3d8fe42bba816";
       };
     };
 


### PR DESCRIPTION
Update `flake.nix` to match `v0.19.0` release assets.

The hashes come from the Linux checksum files generated during the release build.