### PR TITLE
feat: add Arch Linux PKGBUILD for AUR deployment

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: A Akhil <https://github.com/A-Akhil/>
+
+pkgname=antigravity-manager-bin
+_pkgname=antigravity-manager
+pkgver=0.19.0
+pkgrel=1
+pkgdesc="Antigravity Manager - Electron App"
+arch=('x86_64')
+url="https://github.com/Draculabo/AntigravityManager"
+license=('custom:CC-BY-NC-SA-4.0')
+depends=('nss' 'alsa-lib' 'gtk3')
+provides=("${_pkgname}")
+conflicts=("${_pkgname}")
+source=("https://github.com/Draculabo/AntigravityManager/releases/download/v${pkgver}/Antigravity.Manager_${pkgver}_amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+  # makepkg automatically extracts the .deb file into data.tar.* and control.tar.*
+  # We just need to extract the data archive into our package directory
+  tar -xf data.tar.* -C "${pkgdir}"
+
+  # Optionally clean up any lintian files if they exist in the deb
+  rm -rf "${pkgdir}/usr/share/lintian"
+}

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,0 +1,22 @@
+# Arch Linux Packaging
+
+This directory contains the PKGBUILD necessary to install Antigravity Manager on Arch Linux using the pre-compiled `.deb` binaries.
+
+This is a `-bin` package (`antigravity-manager-bin`), which means it does not require you to compile Node.js, `better-sqlite3`, or any native dependencies from source. It downloads the pre-packaged `.deb` release created by GitHub Actions and repackages it for Arch Linux. This is the fastest, safest, and most common way to distribute Electron apps on the AUR.
+
+## Building with `makepkg` (Local Build)
+
+If you want to build and install the package locally using `makepkg`:
+
+1. Copy the `PKGBUILD` to an empty directory.
+2. Run `makepkg -si`. This will download the `.deb` release, extract it, and install it on your system using `pacman`.
+
+## Publishing to the AUR
+
+To deploy to the AUR (so users can install it using `yay -S antigravity-manager-bin`), you should:
+1. Initialize an AUR git repository for `antigravity-manager-bin`.
+2. Add the `PKGBUILD` file to it.
+3. Generate `.SRCINFO` by running: `makepkg --printsrcinfo > .SRCINFO`
+4. Commit and push both files to the AUR repository.
+
+Note: Remember to update `pkgver` and regenerate `.SRCINFO` for each new version you release.


### PR DESCRIPTION
This PR adds a PKGBUILD for Arch Linux packaging. This is a `-bin` package (`antigravity-manager-bin`) which installs using the pre-compiled `.deb` binaries. This avoids the need to build native dependencies from source on the user's machine.