### PR TITLE
docs: add Arch Linux AUR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Download the latest release for your platform from the [Releases](https://github
 | Windows (x64/ARM64) | [.exe installer](https://github.com/Draculabo/AntigravityManager/releases/latest) |
 | macOS | [.dmg installer](https://github.com/Draculabo/AntigravityManager/releases/latest) |
 | Linux | [.deb / .rpm](https://github.com/Draculabo/AntigravityManager/releases/latest) |
+| Arch Linux (AUR) | `yay -S antigravity-manager-bin` |
 | NixOS / Nix | `nix run github:Draculabo/AntigravityManager` |
 
 ### ❄️ Nix Integration

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: A Akhil <https://github.com/A-Akhil/>
+
+pkgname=antigravity-manager-bin
+_pkgname=antigravity-manager
+pkgver=0.19.0
+pkgrel=1
+pkgdesc="Antigravity Manager - Electron App"
+arch=('x86_64')
+url="https://github.com/Draculabo/AntigravityManager"
+license=('custom:CC-BY-NC-SA-4.0')
+depends=('nss' 'alsa-lib' 'gtk3')
+provides=("${_pkgname}")
+conflicts=("${_pkgname}")
+source=("https://github.com/Draculabo/AntigravityManager/releases/download/v${pkgver}/Antigravity.Manager_${pkgver}_amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+  # makepkg automatically extracts the .deb file into data.tar.* and control.tar.*
+  # We just need to extract the data archive into our package directory
+  tar -xf data.tar.* -C "${pkgdir}"
+
+  # Optionally clean up any lintian files if they exist in the deb
+  rm -rf "${pkgdir}/usr/share/lintian"
+}

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,0 +1,22 @@
+# Arch Linux Packaging
+
+This directory contains the PKGBUILD necessary to install Antigravity Manager on Arch Linux using the pre-compiled `.deb` binaries.
+
+This is a `-bin` package (`antigravity-manager-bin`), which means it does not require you to compile Node.js, `better-sqlite3`, or any native dependencies from source. It downloads the pre-packaged `.deb` release created by GitHub Actions and repackages it for Arch Linux. This is the fastest, safest, and most common way to distribute Electron apps on the AUR.
+
+## Building with `makepkg` (Local Build)
+
+If you want to build and install the package locally using `makepkg`:
+
+1. Copy the `PKGBUILD` to an empty directory.
+2. Run `makepkg -si`. This will download the `.deb` release, extract it, and install it on your system using `pacman`.
+
+## Publishing to the AUR
+
+To deploy to the AUR (so users can install it using `yay -S antigravity-manager-bin`), you should:
+1. Initialize an AUR git repository for `antigravity-manager-bin`.
+2. Add the `PKGBUILD` file to it.
+3. Generate `.SRCINFO` by running: `makepkg --printsrcinfo > .SRCINFO`
+4. Commit and push both files to the AUR repository.
+
+Note: Remember to update `pkgver` and regenerate `.SRCINFO` for each new version you release.


### PR DESCRIPTION
This PR updates the README download table to include instructions for installing the app from the AUR using `yay -S antigravity-manager-bin`, since the AUR package is now officially published and maintained.