### PR TITLE
feat(proxy): retain opt-in OpenAI session history

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ When using Antigravity IDE, have you ever encountered these problems?
         <li>OpenAI & Anthropic API compatible</li>
         <li>Configurable port and request timeout</li>
         <li>Model mapping (e.g. Claude → Gemini)</li>
+        <li>
+          <a href="docs/openai-session-history.md">Optional server-managed OpenAI session history</a>
+        </li>
       </ul>
     </td>
     <td width="50%">

--- a/docs/openai-session-history.md
+++ b/docs/openai-session-history.md
@@ -20,6 +20,10 @@ stored user, assistant, and tool-call messages before forwarding the request ups
 Use an unguessable ID per logical conversation. Requests that share a `session_id` intentionally share
 the same history.
 
+Requests for the same session are processed in order. A later turn waits until the preceding response
+has completed, including consumption or cancellation of a streaming response. Different session IDs
+remain independent and can run concurrently.
+
 ## Controls
 
 - `session_reset: true` clears the stored history before the current turn.
@@ -30,6 +34,10 @@ the same history.
 History is process-local, expires after six hours of inactivity, and is bounded by both session count
 and serialized character size. Restarting Antigravity Manager clears it. Use client-managed `messages`
 when history must survive restarts or be stored durably.
+
+The gateway uses `session_id` as the sole history key and does not authenticate ownership of that ID.
+Treat it as a secret, keep the gateway bound to a trusted interface or place authentication in front of
+it, and never reuse a session ID between clients that must not share context.
 
 This is an Antigravity extension, not a standard Chat Completions field. The standard OpenAI guidance
 is to manage Chat Completions history in the client or use the stateful Responses and Conversations

--- a/docs/openai-session-history.md
+++ b/docs/openai-session-history.md
@@ -1,0 +1,36 @@
+# OpenAI-compatible session history
+
+`POST /v1/chat/completions` remains stateless by default. Clients that already resend the full
+`messages` array do not need this extension.
+
+Antigravity Manager can keep conversation history in memory when a request includes an explicit
+`session_id`:
+
+```json
+{
+  "model": "gemini-3-flash",
+  "session_id": "interview-2026-07-11",
+  "messages": [{ "role": "user", "content": "Remember this context from the first turn." }]
+}
+```
+
+Subsequent requests may send only the newest message with the same `session_id`. The gateway adds
+stored user, assistant, and tool-call messages before forwarding the request upstream.
+
+Use an unguessable ID per logical conversation. Requests that share a `session_id` intentionally share
+the same history.
+
+## Controls
+
+- `session_reset: true` clears the stored history before the current turn.
+- `session_store: false` makes the current request stateless without deleting stored history.
+- `extra.session_bootstrap` or `extra.session_bootstrap_context` adds initial system context once.
+- `extra.session_bootstrap_messages` adds initial OpenAI-compatible messages once.
+
+History is process-local, expires after six hours of inactivity, and is bounded by both session count
+and serialized character size. Restarting Antigravity Manager clears it. Use client-managed `messages`
+when history must survive restarts or be stored durably.
+
+This is an Antigravity extension, not a standard Chat Completions field. The standard OpenAI guidance
+is to manage Chat Completions history in the client or use the stateful Responses and Conversations
+APIs: <https://developers.openai.com/api/docs/guides/conversation-state>.

--- a/src/modules/proxy-gateway/server/interfaces/request-interfaces.ts
+++ b/src/modules/proxy-gateway/server/interfaces/request-interfaces.ts
@@ -11,6 +11,12 @@ export interface OpenAIChatRequest {
   tool_choice?: string | { type: string; function?: { name: string } };
   response_format?: { type?: string };
   extra?: Record<string, unknown>;
+  /** Opt-in Antigravity extension for server-managed Chat Completions history. */
+  session_id?: string;
+  /** Clears the stored history before processing this turn. */
+  session_reset?: boolean;
+  /** Set to false to keep this request stateless even when session_id is present. */
+  session_store?: boolean;
 }
 
 export interface OpenAIMessage {

--- a/src/modules/proxy-gateway/server/openai-session-store.ts
+++ b/src/modules/proxy-gateway/server/openai-session-store.ts
@@ -1,0 +1,403 @@
+import { isEmpty, isPlainObject, isString } from 'lodash-es';
+import { Observable } from 'rxjs';
+import type {
+  OpenAIChatRequest,
+  OpenAIChatResponse,
+  OpenAIMessage,
+  OpenAIToolCall,
+} from './interfaces/request-interfaces';
+
+interface SessionState {
+  messages: OpenAIMessage[];
+  lastAccessedAt: number;
+}
+
+export interface OpenAISessionStoreOptions {
+  maxHistoryChars?: number;
+  maxSessions?: number;
+  sessionTtlMs?: number;
+}
+
+export interface PreparedOpenAISessionRequest {
+  request: OpenAIChatRequest;
+  sessionId?: string;
+  shouldStore: boolean;
+  newMessages: OpenAIMessage[];
+}
+
+interface MergeResult {
+  messages: OpenAIMessage[];
+  newMessages: OpenAIMessage[];
+}
+
+interface StreamAssistantAccumulator {
+  content: string;
+  toolCalls: Map<number, OpenAIToolCall>;
+}
+
+interface StreamToolCallDelta {
+  index?: number;
+  id?: unknown;
+  type?: unknown;
+  function?: {
+    name?: unknown;
+    arguments?: unknown;
+  };
+}
+
+const DEFAULT_MAX_HISTORY_CHARS = 1_000_000;
+const DEFAULT_MAX_SESSIONS = 64;
+const DEFAULT_SESSION_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Adds opt-in state to the otherwise stateless OpenAI Chat Completions endpoint.
+ * Clients that omit session_id continue to use the standard stateless contract.
+ */
+export class OpenAISessionStore {
+  private readonly sessions = new Map<string, SessionState>();
+  private readonly maxHistoryChars: number;
+  private readonly maxSessions: number;
+  private readonly sessionTtlMs: number;
+
+  constructor(options: OpenAISessionStoreOptions = {}) {
+    this.maxHistoryChars = options.maxHistoryChars ?? DEFAULT_MAX_HISTORY_CHARS;
+    this.maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.sessionTtlMs = options.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
+  }
+
+  prepareRequest(request: OpenAIChatRequest): PreparedOpenAISessionRequest {
+    const sessionId = this.extractSessionId(request);
+    if (!sessionId || this.isStoreDisabled(request)) {
+      return { request, shouldStore: false, newMessages: [] };
+    }
+
+    this.pruneExpiredSessions();
+    if (this.shouldResetSession(request)) {
+      this.sessions.delete(sessionId);
+    }
+
+    const state = this.getOrCreateSession(sessionId);
+    const incomingMessages = [
+      ...this.extractBootstrapMessages(request),
+      ...this.cloneMessages(request.messages ?? []),
+    ];
+    const merged = this.mergeMessages(state.messages, incomingMessages);
+    state.lastAccessedAt = Date.now();
+    this.enforceMaxSessions();
+
+    return {
+      request: {
+        ...request,
+        messages: merged.messages,
+        extra: this.cleanSessionControls(request.extra, sessionId),
+      },
+      sessionId,
+      shouldStore: true,
+      newMessages: merged.newMessages,
+    };
+  }
+
+  recordResponse(prepared: PreparedOpenAISessionRequest, response: OpenAIChatResponse): void {
+    const assistantMessage = this.assistantMessageFromResponse(response);
+    this.commitMessages(prepared, assistantMessage ? [assistantMessage] : []);
+  }
+
+  recordStreamResponse(
+    prepared: PreparedOpenAISessionRequest,
+    stream: Observable<string>,
+  ): Observable<string> {
+    if (!prepared.shouldStore || !prepared.sessionId) {
+      return stream;
+    }
+
+    return new Observable<string>((subscriber) => {
+      const assistant: StreamAssistantAccumulator = {
+        content: '',
+        toolCalls: new Map<number, OpenAIToolCall>(),
+      };
+      const subscription = stream.subscribe({
+        next: (chunk) => {
+          this.accumulateStreamChunk(chunk, assistant);
+          subscriber.next(chunk);
+        },
+        error: (error) => subscriber.error(error),
+        complete: () => {
+          const assistantMessage = this.assistantMessageFromStream(assistant);
+          this.commitMessages(prepared, assistantMessage ? [assistantMessage] : []);
+          subscriber.complete();
+        },
+      });
+
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  private commitMessages(
+    prepared: PreparedOpenAISessionRequest,
+    assistantMessages: OpenAIMessage[],
+  ): void {
+    if (!prepared.shouldStore || !prepared.sessionId) {
+      return;
+    }
+
+    this.pruneExpiredSessions();
+    const state = this.getOrCreateSession(prepared.sessionId);
+    state.messages = this.trimMessages([
+      ...state.messages,
+      ...this.cloneMessages(prepared.newMessages),
+      ...this.cloneMessages(assistantMessages),
+    ]);
+    state.lastAccessedAt = Date.now();
+    this.enforceMaxSessions();
+  }
+
+  private mergeMessages(stored: OpenAIMessage[], incoming: OpenAIMessage[]): MergeResult {
+    const overlap = this.findSuffixPrefixOverlap(stored, incoming);
+    const newMessages = incoming.slice(overlap);
+    return {
+      messages: this.trimMessages([...stored, ...newMessages]),
+      newMessages,
+    };
+  }
+
+  private findSuffixPrefixOverlap(stored: OpenAIMessage[], incoming: OpenAIMessage[]): number {
+    const maxOverlap = Math.min(stored.length, incoming.length);
+    for (let length = maxOverlap; length > 0; length -= 1) {
+      const storedSlice = stored.slice(stored.length - length);
+      const incomingSlice = incoming.slice(0, length);
+      if (this.sameMessages(storedSlice, incomingSlice)) {
+        return length;
+      }
+    }
+    return 0;
+  }
+
+  private sameMessages(left: OpenAIMessage[], right: OpenAIMessage[]): boolean {
+    return (
+      left.length === right.length &&
+      left.every((message, index) => this.fingerprint(message) === this.fingerprint(right[index]))
+    );
+  }
+
+  private assistantMessageFromResponse(response: OpenAIChatResponse): OpenAIMessage | null {
+    const message = response.choices?.[0]?.message;
+    if (!message) {
+      return null;
+    }
+
+    const content = isString(message.content) ? message.content : '';
+    const toolCalls = this.cloneToolCalls(message.tool_calls);
+    if (isEmpty(content.trim()) && isEmpty(toolCalls)) {
+      return null;
+    }
+    return { role: 'assistant', content, tool_calls: toolCalls };
+  }
+
+  private assistantMessageFromStream(assistant: StreamAssistantAccumulator): OpenAIMessage | null {
+    const toolCalls = [...assistant.toolCalls.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([, toolCall]) => toolCall)
+      .filter((toolCall) => Boolean(toolCall.id && toolCall.function.name));
+    if (isEmpty(assistant.content.trim()) && toolCalls.length === 0) {
+      return null;
+    }
+    return {
+      role: 'assistant',
+      content: assistant.content,
+      tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+    };
+  }
+
+  private accumulateStreamChunk(chunk: string, assistant: StreamAssistantAccumulator): void {
+    for (const line of String(chunk).split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data: ')) {
+        continue;
+      }
+      const payload = trimmed.slice(6).trim();
+      if (!payload || payload === '[DONE]') {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(payload) as {
+          choices?: Array<{
+            delta?: { content?: unknown; tool_calls?: StreamToolCallDelta[] };
+          }>;
+        };
+        const delta = parsed.choices?.[0]?.delta;
+        if (isString(delta?.content)) {
+          assistant.content += delta.content;
+        }
+        for (const toolCallDelta of delta?.tool_calls ?? []) {
+          this.accumulateToolCall(toolCallDelta, assistant.toolCalls);
+        }
+      } catch {
+        // Ignore metadata or malformed SSE chunks while preserving the client stream.
+      }
+    }
+  }
+
+  private accumulateToolCall(
+    delta: StreamToolCallDelta,
+    toolCalls: Map<number, OpenAIToolCall>,
+  ): void {
+    const index = typeof delta.index === 'number' ? delta.index : 0;
+    const current = toolCalls.get(index) ?? {
+      id: '',
+      type: 'function' as const,
+      function: { name: '', arguments: '' },
+    };
+    if (isString(delta.id)) {
+      current.id = delta.id;
+    }
+    if (isString(delta.function?.name)) {
+      current.function.name += delta.function.name;
+    }
+    if (isString(delta.function?.arguments)) {
+      current.function.arguments += delta.function.arguments;
+    }
+    toolCalls.set(index, current);
+  }
+
+  private extractBootstrapMessages(request: OpenAIChatRequest): OpenAIMessage[] {
+    const extra = this.toRecord(request.extra);
+    const bootstrapMessages = this.asMessageArray(extra?.session_bootstrap_messages);
+    const bootstrapText = this.firstString([
+      extra?.session_bootstrap,
+      extra?.session_bootstrap_context,
+    ]);
+    if (!bootstrapText) {
+      return bootstrapMessages;
+    }
+    return [...bootstrapMessages, { role: 'system', content: bootstrapText }];
+  }
+
+  private extractSessionId(request: OpenAIChatRequest): string | undefined {
+    const extra = this.toRecord(request.extra);
+    return this.firstString([request.session_id, extra?.session_id, extra?.sessionId]);
+  }
+
+  private shouldResetSession(request: OpenAIChatRequest): boolean {
+    const extra = this.toRecord(request.extra);
+    return request.session_reset === true || extra?.session_reset === true;
+  }
+
+  private isStoreDisabled(request: OpenAIChatRequest): boolean {
+    const extra = this.toRecord(request.extra);
+    return request.session_store === false || extra?.session_store === false;
+  }
+
+  private cleanSessionControls(value: unknown, sessionId: string): Record<string, unknown> {
+    const cleaned = { ...(this.toRecord(value) ?? {}) };
+    for (const key of [
+      'session_bootstrap_messages',
+      'session_bootstrap',
+      'session_bootstrap_context',
+      'session_reset',
+      'session_store',
+    ]) {
+      delete cleaned[key];
+    }
+    cleaned.session_id = sessionId;
+    return cleaned;
+  }
+
+  private trimMessages(messages: OpenAIMessage[]): OpenAIMessage[] {
+    const systemMessages = messages.filter((message) => message.role === 'system');
+    const nonSystemMessages = messages.filter((message) => message.role !== 'system');
+    const keptSystem: OpenAIMessage[] = [];
+    let usedChars = 0;
+
+    for (const message of systemMessages) {
+      const size = this.measureMessage(message);
+      if (usedChars + size <= this.maxHistoryChars) {
+        keptSystem.push(message);
+        usedChars += size;
+      }
+    }
+
+    const keptNonSystem: OpenAIMessage[] = [];
+    for (let index = nonSystemMessages.length - 1; index >= 0; index -= 1) {
+      const message = nonSystemMessages[index];
+      const size = this.measureMessage(message);
+      if (usedChars + size > this.maxHistoryChars) {
+        continue;
+      }
+      keptNonSystem.unshift(message);
+      usedChars += size;
+    }
+    return [...keptSystem, ...keptNonSystem];
+  }
+
+  private getOrCreateSession(sessionId: string): SessionState {
+    const existing = this.sessions.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+    const created = { messages: [], lastAccessedAt: Date.now() };
+    this.sessions.set(sessionId, created);
+    return created;
+  }
+
+  private pruneExpiredSessions(): void {
+    const expiresBefore = Date.now() - this.sessionTtlMs;
+    for (const [sessionId, state] of this.sessions) {
+      if (state.lastAccessedAt < expiresBefore) {
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+
+  private enforceMaxSessions(): void {
+    while (this.sessions.size > this.maxSessions) {
+      const oldest = [...this.sessions.entries()].sort(
+        ([, left], [, right]) => left.lastAccessedAt - right.lastAccessedAt,
+      )[0];
+      if (!oldest) {
+        return;
+      }
+      this.sessions.delete(oldest[0]);
+    }
+  }
+
+  private asMessageArray(value: unknown): OpenAIMessage[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.filter((item): item is OpenAIMessage => {
+      if (!isPlainObject(item)) {
+        return false;
+      }
+      const message = item as { role?: unknown; content?: unknown };
+      return (
+        isString(message.role) && (isString(message.content) || Array.isArray(message.content))
+      );
+    });
+  }
+
+  private firstString(values: unknown[]): string | undefined {
+    const value = values.find((candidate) => isString(candidate) && !isEmpty(candidate.trim()));
+    return isString(value) ? value.trim() : undefined;
+  }
+
+  private toRecord(value: unknown): Record<string, unknown> | undefined {
+    return isPlainObject(value) ? (value as Record<string, unknown>) : undefined;
+  }
+
+  private cloneMessages(messages: OpenAIMessage[]): OpenAIMessage[] {
+    return structuredClone(messages);
+  }
+
+  private cloneToolCalls(toolCalls: OpenAIToolCall[] | undefined): OpenAIToolCall[] | undefined {
+    return toolCalls ? structuredClone(toolCalls) : undefined;
+  }
+
+  private measureMessage(message: OpenAIMessage): number {
+    return this.fingerprint(message).length;
+  }
+
+  private fingerprint(message: OpenAIMessage): string {
+    return JSON.stringify(message);
+  }
+}

--- a/src/modules/proxy-gateway/server/openai-session-store.ts
+++ b/src/modules/proxy-gateway/server/openai-session-store.ts
@@ -23,6 +23,7 @@ export interface PreparedOpenAISessionRequest {
   sessionId?: string;
   shouldStore: boolean;
   newMessages: OpenAIMessage[];
+  releaseSession: () => void;
 }
 
 interface MergeResult {
@@ -55,6 +56,7 @@ const DEFAULT_SESSION_TTL_MS = 6 * 60 * 60 * 1000;
  */
 export class OpenAISessionStore {
   private readonly sessions = new Map<string, SessionState>();
+  private readonly sessionTails = new Map<string, Promise<void>>();
   private readonly maxHistoryChars: number;
   private readonly maxSessions: number;
   private readonly sessionTtlMs: number;
@@ -65,41 +67,61 @@ export class OpenAISessionStore {
     this.sessionTtlMs = options.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
   }
 
-  prepareRequest(request: OpenAIChatRequest): PreparedOpenAISessionRequest {
+  async prepareRequest(request: OpenAIChatRequest): Promise<PreparedOpenAISessionRequest> {
     const sessionId = this.extractSessionId(request);
     if (!sessionId || this.isStoreDisabled(request)) {
-      return { request, shouldStore: false, newMessages: [] };
+      return {
+        request,
+        shouldStore: false,
+        newMessages: [],
+        releaseSession: () => undefined,
+      };
     }
 
-    this.pruneExpiredSessions();
-    if (this.shouldResetSession(request)) {
-      this.sessions.delete(sessionId);
+    const releaseSession = await this.acquireSession(sessionId);
+    try {
+      this.pruneExpiredSessions();
+      if (this.shouldResetSession(request)) {
+        this.sessions.delete(sessionId);
+      }
+
+      const state = this.getOrCreateSession(sessionId);
+      const incomingMessages = [
+        ...this.extractBootstrapMessages(request),
+        ...this.cloneMessages(request.messages ?? []),
+      ];
+      const merged = this.mergeMessages(state.messages, incomingMessages);
+      state.lastAccessedAt = Date.now();
+      this.enforceMaxSessions();
+
+      return {
+        request: {
+          ...request,
+          messages: merged.messages,
+          extra: this.cleanSessionControls(request.extra, sessionId),
+        },
+        sessionId,
+        shouldStore: true,
+        newMessages: merged.newMessages,
+        releaseSession,
+      };
+    } catch (error) {
+      releaseSession();
+      throw error;
     }
-
-    const state = this.getOrCreateSession(sessionId);
-    const incomingMessages = [
-      ...this.extractBootstrapMessages(request),
-      ...this.cloneMessages(request.messages ?? []),
-    ];
-    const merged = this.mergeMessages(state.messages, incomingMessages);
-    state.lastAccessedAt = Date.now();
-    this.enforceMaxSessions();
-
-    return {
-      request: {
-        ...request,
-        messages: merged.messages,
-        extra: this.cleanSessionControls(request.extra, sessionId),
-      },
-      sessionId,
-      shouldStore: true,
-      newMessages: merged.newMessages,
-    };
   }
 
   recordResponse(prepared: PreparedOpenAISessionRequest, response: OpenAIChatResponse): void {
-    const assistantMessage = this.assistantMessageFromResponse(response);
-    this.commitMessages(prepared, assistantMessage ? [assistantMessage] : []);
+    try {
+      const assistantMessage = this.assistantMessageFromResponse(response);
+      this.commitMessages(prepared, assistantMessage ? [assistantMessage] : []);
+    } finally {
+      prepared.releaseSession();
+    }
+  }
+
+  abandonRequest(prepared: PreparedOpenAISessionRequest): void {
+    prepared.releaseSession();
   }
 
   recordStreamResponse(
@@ -120,16 +142,57 @@ export class OpenAISessionStore {
           this.accumulateStreamChunk(chunk, assistant);
           subscriber.next(chunk);
         },
-        error: (error) => subscriber.error(error),
+        error: (error) => {
+          prepared.releaseSession();
+          subscriber.error(error);
+        },
         complete: () => {
-          const assistantMessage = this.assistantMessageFromStream(assistant);
-          this.commitMessages(prepared, assistantMessage ? [assistantMessage] : []);
-          subscriber.complete();
+          try {
+            const assistantMessage = this.assistantMessageFromStream(assistant);
+            this.commitMessages(prepared, assistantMessage ? [assistantMessage] : []);
+            subscriber.complete();
+          } catch (error) {
+            subscriber.error(error);
+          } finally {
+            prepared.releaseSession();
+          }
         },
       });
 
-      return () => subscription.unsubscribe();
+      return () => {
+        subscription.unsubscribe();
+        prepared.releaseSession();
+      };
     });
+  }
+
+  /**
+   * Serialize turns within one conversation so every request observes the response from the
+   * preceding turn. Separate session IDs retain full concurrency.
+   */
+  private async acquireSession(sessionId: string): Promise<() => void> {
+    const previous = this.sessionTails.get(sessionId) ?? Promise.resolve();
+    let resolveCurrent: () => void = () => undefined;
+    const current = new Promise<void>((resolve) => {
+      resolveCurrent = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.sessionTails.set(sessionId, tail);
+    await previous;
+
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      resolveCurrent();
+      void tail.then(() => {
+        if (this.sessionTails.get(sessionId) === tail) {
+          this.sessionTails.delete(sessionId);
+        }
+      });
+    };
   }
 
   private commitMessages(

--- a/src/modules/proxy-gateway/server/openai-session-store.ts
+++ b/src/modules/proxy-gateway/server/openai-session-store.ts
@@ -47,6 +47,7 @@ interface StreamToolCallDelta {
 }
 
 const DEFAULT_MAX_HISTORY_CHARS = 1_000_000;
+const MAX_SYSTEM_HISTORY_SHARE = 0.5;
 const DEFAULT_MAX_SESSIONS = 64;
 const DEFAULT_SESSION_TTL_MS = 6 * 60 * 60 * 1000;
 
@@ -370,11 +371,24 @@ export class OpenAISessionStore {
     const systemMessages = messages.filter((message) => message.role === 'system');
     const nonSystemMessages = messages.filter((message) => message.role !== 'system');
     const keptSystem: OpenAIMessage[] = [];
+    // Cap system context and reserve the latest turn whenever it can fit in the total budget.
+    const latestNonSystemMessage = nonSystemMessages.at(-1);
+    const latestNonSystemChars = latestNonSystemMessage
+      ? this.measureMessage(latestNonSystemMessage)
+      : 0;
+    const reservedNonSystemChars =
+      latestNonSystemChars <= this.maxHistoryChars ? latestNonSystemChars : 0;
+    const systemBudget = latestNonSystemMessage
+      ? Math.min(
+          Math.floor(this.maxHistoryChars * MAX_SYSTEM_HISTORY_SHARE),
+          this.maxHistoryChars - reservedNonSystemChars,
+        )
+      : this.maxHistoryChars;
     let usedChars = 0;
 
     for (const message of systemMessages) {
       const size = this.measureMessage(message);
-      if (usedChars + size <= this.maxHistoryChars) {
+      if (usedChars + size <= systemBudget) {
         keptSystem.push(message);
         usedChars += size;
       }

--- a/src/modules/proxy-gateway/server/openai-session-store.ts
+++ b/src/modules/proxy-gateway/server/openai-session-store.ts
@@ -88,7 +88,7 @@ export class OpenAISessionStore {
 
       const state = this.getOrCreateSession(sessionId);
       const incomingMessages = [
-        ...this.extractBootstrapMessages(request),
+        ...(state.messages.length === 0 ? this.extractBootstrapMessages(request) : []),
         ...this.cloneMessages(request.messages ?? []),
       ];
       const merged = this.mergeMessages(state.messages, incomingMessages);
@@ -475,6 +475,16 @@ export class OpenAISessionStore {
   }
 
   private fingerprint(message: OpenAIMessage): string {
-    return JSON.stringify(message);
+    // Ignore object key order without changing JSON's treatment of omitted undefined fields.
+    return JSON.stringify(message, (_key, value: unknown) => {
+      if (!isPlainObject(value)) {
+        return value;
+      }
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+          left.localeCompare(right),
+        ),
+      );
+    });
   }
 }

--- a/src/modules/proxy-gateway/server/proxy.service.ts
+++ b/src/modules/proxy-gateway/server/proxy.service.ts
@@ -692,14 +692,25 @@ export class ProxyService {
   async handleChatCompletions(
     request: OpenAIChatRequest,
   ): Promise<OpenAIChatResponse | Observable<string>> {
-    const preparedSessionRequest = this.openaiSessionStore.prepareRequest(request);
+    const preparedSessionRequest = await this.openaiSessionStore.prepareRequest(request);
+    try {
+      return await this.handlePreparedChatCompletions(preparedSessionRequest);
+    } catch (error) {
+      this.openaiSessionStore.abandonRequest(preparedSessionRequest);
+      throw error;
+    }
+  }
+
+  private async handlePreparedChatCompletions(
+    preparedSessionRequest: PreparedOpenAISessionRequest,
+  ): Promise<OpenAIChatResponse | Observable<string>> {
     const effectiveRequest = preparedSessionRequest.request;
     const sessionKey = this.extractOpenAISessionKey(effectiveRequest);
 
     const targetModel = this.resolveTargetModel(effectiveRequest.model);
     const extraHeaders = this.createModelSpecificHeaders(effectiveRequest.model);
     this.logger.log(
-      `OpenAI-compatible request received: model=${effectiveRequest.model}, mappedModel=${targetModel}, stream=${effectiveRequest.stream}, session=${preparedSessionRequest.sessionId ?? 'none'}`,
+      `OpenAI-compatible request received: model=${effectiveRequest.model}, mappedModel=${targetModel}, stream=${effectiveRequest.stream}, session=${preparedSessionRequest.shouldStore ? 'enabled' : 'none'}`,
     );
 
     // Retry loop for account selection

--- a/src/modules/proxy-gateway/server/proxy.service.ts
+++ b/src/modules/proxy-gateway/server/proxy.service.ts
@@ -34,6 +34,7 @@ import {
   type ProxyUpstreamFailureClassification,
 } from './proxy-retry-policy';
 import { ProxyModelRoutingPolicy } from './proxy-model-routing-policy';
+import { OpenAISessionStore, type PreparedOpenAISessionRequest } from './openai-session-store';
 
 interface StreamIdleTimer {
   reset: () => void;
@@ -48,6 +49,7 @@ export class ProxyService {
   private readonly generationConstraints: ProxyGenerationConstraints;
   private readonly retryPolicy: ProxyRetryPolicy;
   private readonly modelRoutingPolicy = new ProxyModelRoutingPolicy();
+  private readonly openaiSessionStore = new OpenAISessionStore();
 
   constructor(
     @Inject(AccountLeaseService) private readonly accountLeaseService: AccountLeaseService,
@@ -690,12 +692,14 @@ export class ProxyService {
   async handleChatCompletions(
     request: OpenAIChatRequest,
   ): Promise<OpenAIChatResponse | Observable<string>> {
-    const sessionKey = this.extractOpenAISessionKey(request);
+    const preparedSessionRequest = this.openaiSessionStore.prepareRequest(request);
+    const effectiveRequest = preparedSessionRequest.request;
+    const sessionKey = this.extractOpenAISessionKey(effectiveRequest);
 
-    const targetModel = this.resolveTargetModel(request.model);
-    const extraHeaders = this.createModelSpecificHeaders(request.model);
+    const targetModel = this.resolveTargetModel(effectiveRequest.model);
+    const extraHeaders = this.createModelSpecificHeaders(effectiveRequest.model);
     this.logger.log(
-      `OpenAI-compatible request received: model=${request.model}, mappedModel=${targetModel}, stream=${request.stream}`,
+      `OpenAI-compatible request received: model=${effectiveRequest.model}, mappedModel=${targetModel}, stream=${effectiveRequest.stream}, session=${preparedSessionRequest.sessionId ?? 'none'}`,
     );
 
     // Retry loop for account selection
@@ -722,7 +726,7 @@ export class ProxyService {
       );
 
       try {
-        const claudeRequest = this.convertOpenAIToClaude(request);
+        const claudeRequest = this.convertOpenAIToClaude(effectiveRequest);
         const projectId = token.token.project_id ?? '';
         const requestUserAgent = await resolveRequestUserAgent();
         const geminiBody = transformClaudeRequestIn(claudeRequest, projectId, requestUserAgent);
@@ -730,7 +734,7 @@ export class ProxyService {
         this.applyInternalGenerationConstraints(geminiBody, effectiveTargetModel, token.id);
 
         // Use v1internal API (same as Anthropic handler)
-        if (request.stream) {
+        if (effectiveRequest.stream) {
           try {
             const stream = await this.geminiClient.streamGenerateInternal(
               geminiBody,
@@ -738,10 +742,13 @@ export class ProxyService {
               token.token.upstream_proxy_url,
               extraHeaders,
             );
-            return this.processStreamResponse(stream, request.model);
+            return this.recordOpenAIStream(
+              preparedSessionRequest,
+              this.processStreamResponse(stream, effectiveRequest.model),
+            );
           } catch (streamError) {
             this.logger.warn(
-              `Stream path failed for model=${request.model}; falling back to non-stream generation: ${
+              `Stream path failed for model=${effectiveRequest.model}; falling back to non-stream generation: ${
                 streamError instanceof Error ? streamError.message : String(streamError)
               }`,
             );
@@ -758,9 +765,12 @@ export class ProxyService {
             const claudeResponse = transformResponse(response);
             const openaiResponse = this.convertClaudeToOpenAIResponse(
               claudeResponse,
-              request.model,
+              effectiveRequest.model,
             );
-            return this.createSyntheticOpenAIStream(openaiResponse);
+            return this.recordOpenAIStream(
+              preparedSessionRequest,
+              this.createSyntheticOpenAIStream(openaiResponse),
+            );
           }
         } else {
           const response = await this.generateInternalWithStreamFallback(
@@ -777,7 +787,10 @@ export class ProxyService {
           this.logger.log(
             `Transformed Claude response snippet: ${JSON.stringify(claudeResponse).substring(0, 500)}`,
           );
-          return this.convertClaudeToOpenAIResponse(claudeResponse, request.model);
+          return this.recordOpenAIResponse(
+            preparedSessionRequest,
+            this.convertClaudeToOpenAIResponse(claudeResponse, effectiveRequest.model),
+          );
         }
       } catch (err) {
         if (err instanceof Error && this.isProjectContextError(err.message)) {
@@ -785,19 +798,22 @@ export class ProxyService {
             `OpenAI compatibility request hit project context issue, retrying without project: ${err.message}`,
           );
           try {
-            const claudeRequest = this.convertOpenAIToClaude(request);
+            const claudeRequest = this.convertOpenAIToClaude(effectiveRequest);
             const requestUserAgent = await resolveRequestUserAgent();
             const fallbackBody = transformClaudeRequestIn(claudeRequest, '', requestUserAgent);
             fallbackBody.model = effectiveTargetModel;
             this.applyInternalGenerationConstraints(fallbackBody, effectiveTargetModel, token.id);
-            if (request.stream) {
+            if (effectiveRequest.stream) {
               const stream = await this.geminiClient.streamGenerateInternal(
                 fallbackBody,
                 token.token.access_token,
                 token.token.upstream_proxy_url,
                 extraHeaders,
               );
-              return this.processStreamResponse(stream, request.model);
+              return this.recordOpenAIStream(
+                preparedSessionRequest,
+                this.processStreamResponse(stream, effectiveRequest.model),
+              );
             }
 
             const response = await this.generateInternalWithStreamFallback(
@@ -807,7 +823,10 @@ export class ProxyService {
               extraHeaders,
             );
             const claudeResponse = transformResponse(response);
-            return this.convertClaudeToOpenAIResponse(claudeResponse, request.model);
+            return this.recordOpenAIResponse(
+              preparedSessionRequest,
+              this.convertClaudeToOpenAIResponse(claudeResponse, effectiveRequest.model),
+            );
           } catch (fallbackErr) {
             lastError = fallbackErr;
           }
@@ -822,6 +841,21 @@ export class ProxyService {
       }
     }
     throw lastError || new Error('Request failed after retries');
+  }
+
+  private recordOpenAIResponse(
+    preparedSessionRequest: PreparedOpenAISessionRequest,
+    response: OpenAIChatResponse,
+  ): OpenAIChatResponse {
+    this.openaiSessionStore.recordResponse(preparedSessionRequest, response);
+    return response;
+  }
+
+  private recordOpenAIStream(
+    preparedSessionRequest: PreparedOpenAISessionRequest,
+    stream: Observable<string>,
+  ): Observable<string> {
+    return this.openaiSessionStore.recordStreamResponse(preparedSessionRequest, stream);
   }
 
   private async generateInternalWithStreamFallback(
@@ -1647,7 +1681,11 @@ export class ProxyService {
   private extractOpenAISessionKey(request: OpenAIChatRequest): string | undefined {
     const extra = request.extra;
     const sessionCandidate =
-      extra?.session_id ?? extra?.sessionId ?? extra?.user_id ?? extra?.userId;
+      request.session_id ??
+      extra?.session_id ??
+      extra?.sessionId ??
+      extra?.user_id ??
+      extra?.userId;
     if (!isString(sessionCandidate) || isEmpty(sessionCandidate.trim())) {
       return undefined;
     }

--- a/src/tests/unit/openai-session-store.test.ts
+++ b/src/tests/unit/openai-session-store.test.ts
@@ -148,22 +148,38 @@ describe('OpenAISessionStore', () => {
     store.abandonRequest(next);
   });
 
+  it('reserves enough history budget for the latest conversation turn', async () => {
+    const store = new OpenAISessionStore({ maxHistoryChars: 120 });
+    const latestMessage = { role: 'user', content: 'x'.repeat(50) };
+    const prepared = await store.prepareRequest(
+      request([
+        { role: 'system', content: 'a'.repeat(20) },
+        { role: 'system', content: 'b'.repeat(20) },
+        latestMessage,
+      ]),
+    );
+    const serializedLength = prepared.request.messages.reduce(
+      (total, message) => total + JSON.stringify(message).length,
+      0,
+    );
+
+    expect(serializedLength).toBeLessThanOrEqual(120);
+    expect(prepared.request.messages.at(-1)).toEqual(latestMessage);
+    store.abandonRequest(prepared);
+  });
+
   it('serializes concurrent turns that use the same session ID', async () => {
     const store = new OpenAISessionStore();
     const first = await store.prepareRequest(
       request([{ role: 'user', content: 'first question' }]),
     );
-    let secondPrepared = false;
-    const secondPromise = store
-      .prepareRequest(request([{ role: 'user', content: 'second question' }]))
-      .then((prepared) => {
-        secondPrepared = true;
-        return prepared;
-      });
+    const secondStarted = createSignal();
+    const secondPromise = (async () => {
+      secondStarted.resolve();
+      return store.prepareRequest(request([{ role: 'user', content: 'second question' }]));
+    })();
 
-    await Promise.resolve();
-    expect(secondPrepared).toBe(false);
-
+    await secondStarted.promise;
     store.recordResponse(first, response('first answer'));
     const second = await secondPromise;
 
@@ -214,6 +230,14 @@ describe('OpenAISessionStore', () => {
     store.abandonRequest(second);
   });
 });
+
+function createSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 async function consume(stream: Observable<string>): Promise<void> {
   await new Promise<void>((resolve, reject) => {

--- a/src/tests/unit/openai-session-store.test.ts
+++ b/src/tests/unit/openai-session-store.test.ts
@@ -1,4 +1,4 @@
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 import { OpenAISessionStore } from '@/modules/proxy-gateway/server/openai-session-store';
 import type {
@@ -36,26 +36,33 @@ function response(content: string): OpenAIChatResponse {
 }
 
 describe('OpenAISessionStore', () => {
-  it('keeps earlier turns when the client sends only the newest message', () => {
+  it('keeps earlier turns when the client sends only the newest message', async () => {
     const store = new OpenAISessionStore();
-    const first = store.prepareRequest(request([{ role: 'user', content: 'first question' }]));
+    const first = await store.prepareRequest(
+      request([{ role: 'user', content: 'first question' }]),
+    );
     store.recordResponse(first, response('first answer'));
 
-    const second = store.prepareRequest(request([{ role: 'user', content: 'second question' }]));
+    const second = await store.prepareRequest(
+      request([{ role: 'user', content: 'second question' }]),
+    );
 
     expect(second.request.messages).toEqual([
       { role: 'user', content: 'first question' },
       { role: 'assistant', content: 'first answer' },
       { role: 'user', content: 'second question' },
     ]);
+    store.abandonRequest(second);
   });
 
-  it('does not duplicate history when the client resends the full conversation', () => {
+  it('does not duplicate history when the client resends the full conversation', async () => {
     const store = new OpenAISessionStore();
-    const first = store.prepareRequest(request([{ role: 'user', content: 'first question' }]));
+    const first = await store.prepareRequest(
+      request([{ role: 'user', content: 'first question' }]),
+    );
     store.recordResponse(first, response('first answer'));
 
-    const second = store.prepareRequest(
+    const second = await store.prepareRequest(
       request([
         { role: 'user', content: 'first question' },
         { role: 'assistant', content: 'first answer' },
@@ -64,27 +71,33 @@ describe('OpenAISessionStore', () => {
     );
 
     expect(second.request.messages).toHaveLength(3);
+    store.abandonRequest(second);
   });
 
-  it('resets or disables history only through explicit session controls', () => {
+  it('resets or disables history only through explicit session controls', async () => {
     const store = new OpenAISessionStore();
-    const first = store.prepareRequest(request([{ role: 'user', content: 'first question' }]));
+    const first = await store.prepareRequest(
+      request([{ role: 'user', content: 'first question' }]),
+    );
     store.recordResponse(first, response('first answer'));
 
-    const reset = store.prepareRequest(
+    const reset = await store.prepareRequest(
       request([{ role: 'user', content: 'new conversation' }], { session_reset: true }),
     );
-    const disabled = store.prepareRequest(
+    const disabled = await store.prepareRequest(
       request([{ role: 'user', content: 'stateless' }], { session_store: false }),
     );
 
     expect(reset.request.messages).toEqual([{ role: 'user', content: 'new conversation' }]);
     expect(disabled.shouldStore).toBe(false);
+    store.abandonRequest(reset);
   });
 
   it('reconstructs streamed tool calls for the next turn', async () => {
     const store = new OpenAISessionStore();
-    const prepared = store.prepareRequest(request([{ role: 'user', content: 'check weather' }]));
+    const prepared = await store.prepareRequest(
+      request([{ role: 'user', content: 'check weather' }]),
+    );
     const stream = of(
       'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"weather","arguments":"{\\"city\\":"}}]}}]}\n\n',
       'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"Samara\\"}"}}]}}]}\n\n',
@@ -92,7 +105,7 @@ describe('OpenAISessionStore', () => {
     );
 
     await consume(store.recordStreamResponse(prepared, stream));
-    const next = store.prepareRequest(
+    const next = await store.prepareRequest(
       request([{ role: 'tool', tool_call_id: 'call-1', content: 'sunny' }]),
     );
 
@@ -107,11 +120,12 @@ describe('OpenAISessionStore', () => {
         },
       ],
     });
+    store.abandonRequest(next);
   });
 
-  it('keeps stored history within the configured character budget', () => {
+  it('keeps stored history within the configured character budget', async () => {
     const store = new OpenAISessionStore({ maxHistoryChars: 120 });
-    const first = store.prepareRequest(
+    const first = await store.prepareRequest(
       request([
         { role: 'system', content: 'stable instructions' },
         { role: 'user', content: 'x'.repeat(100) },
@@ -119,7 +133,7 @@ describe('OpenAISessionStore', () => {
     );
     store.recordResponse(first, response('y'.repeat(100)));
 
-    const next = store.prepareRequest(request([{ role: 'user', content: 'latest' }]));
+    const next = await store.prepareRequest(request([{ role: 'user', content: 'latest' }]));
     const serializedLength = next.request.messages.reduce(
       (total, message) => total + JSON.stringify(message).length,
       0,
@@ -131,6 +145,73 @@ describe('OpenAISessionStore', () => {
       content: 'stable instructions',
     });
     expect(next.request.messages.at(-1)).toEqual({ role: 'user', content: 'latest' });
+    store.abandonRequest(next);
+  });
+
+  it('serializes concurrent turns that use the same session ID', async () => {
+    const store = new OpenAISessionStore();
+    const first = await store.prepareRequest(
+      request([{ role: 'user', content: 'first question' }]),
+    );
+    let secondPrepared = false;
+    const secondPromise = store
+      .prepareRequest(request([{ role: 'user', content: 'second question' }]))
+      .then((prepared) => {
+        secondPrepared = true;
+        return prepared;
+      });
+
+    await Promise.resolve();
+    expect(secondPrepared).toBe(false);
+
+    store.recordResponse(first, response('first answer'));
+    const second = await secondPromise;
+
+    expect(second.request.messages).toEqual([
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+      { role: 'user', content: 'second question' },
+    ]);
+    store.abandonRequest(second);
+  });
+
+  it('does not serialize requests from different session IDs', async () => {
+    const store = new OpenAISessionStore();
+    const first = await store.prepareRequest(request([{ role: 'user', content: 'first session' }]));
+    const second = await store.prepareRequest(
+      request([{ role: 'user', content: 'second session' }], { session_id: 'session-2' }),
+    );
+
+    expect(second.request.messages).toEqual([{ role: 'user', content: 'second session' }]);
+    store.abandonRequest(first);
+    store.abandonRequest(second);
+  });
+
+  it('releases a queued session when a request is abandoned', async () => {
+    const store = new OpenAISessionStore();
+    const first = await store.prepareRequest(request([{ role: 'user', content: 'failed turn' }]));
+    const secondPromise = store.prepareRequest(request([{ role: 'user', content: 'retry turn' }]));
+
+    store.abandonRequest(first);
+    const second = await secondPromise;
+
+    expect(second.request.messages).toEqual([{ role: 'user', content: 'retry turn' }]);
+    store.abandonRequest(second);
+  });
+
+  it('releases a queued session when a stream fails', async () => {
+    const store = new OpenAISessionStore();
+    const first = await store.prepareRequest(request([{ role: 'user', content: 'stream turn' }]));
+    const stream = store.recordStreamResponse(
+      first,
+      throwError(() => new Error('stream failed')),
+    );
+
+    await expect(consume(stream)).rejects.toThrow('stream failed');
+    const second = await store.prepareRequest(request([{ role: 'user', content: 'next turn' }]));
+
+    expect(second.request.messages).toEqual([{ role: 'user', content: 'next turn' }]);
+    store.abandonRequest(second);
   });
 });
 

--- a/src/tests/unit/openai-session-store.test.ts
+++ b/src/tests/unit/openai-session-store.test.ts
@@ -1,0 +1,141 @@
+import { Observable, of } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { OpenAISessionStore } from '@/modules/proxy-gateway/server/openai-session-store';
+import type {
+  OpenAIChatRequest,
+  OpenAIChatResponse,
+} from '@/modules/proxy-gateway/server/interfaces/request-interfaces';
+
+function request(
+  messages: OpenAIChatRequest['messages'],
+  overrides: Partial<OpenAIChatRequest> = {},
+): OpenAIChatRequest {
+  return {
+    model: 'gemini-3-flash',
+    messages,
+    session_id: 'session-1',
+    ...overrides,
+  };
+}
+
+function response(content: string): OpenAIChatResponse {
+  return {
+    id: 'response-1',
+    object: 'chat.completion',
+    created: 1,
+    model: 'gemini-3-flash',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe('OpenAISessionStore', () => {
+  it('keeps earlier turns when the client sends only the newest message', () => {
+    const store = new OpenAISessionStore();
+    const first = store.prepareRequest(request([{ role: 'user', content: 'first question' }]));
+    store.recordResponse(first, response('first answer'));
+
+    const second = store.prepareRequest(request([{ role: 'user', content: 'second question' }]));
+
+    expect(second.request.messages).toEqual([
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+      { role: 'user', content: 'second question' },
+    ]);
+  });
+
+  it('does not duplicate history when the client resends the full conversation', () => {
+    const store = new OpenAISessionStore();
+    const first = store.prepareRequest(request([{ role: 'user', content: 'first question' }]));
+    store.recordResponse(first, response('first answer'));
+
+    const second = store.prepareRequest(
+      request([
+        { role: 'user', content: 'first question' },
+        { role: 'assistant', content: 'first answer' },
+        { role: 'user', content: 'second question' },
+      ]),
+    );
+
+    expect(second.request.messages).toHaveLength(3);
+  });
+
+  it('resets or disables history only through explicit session controls', () => {
+    const store = new OpenAISessionStore();
+    const first = store.prepareRequest(request([{ role: 'user', content: 'first question' }]));
+    store.recordResponse(first, response('first answer'));
+
+    const reset = store.prepareRequest(
+      request([{ role: 'user', content: 'new conversation' }], { session_reset: true }),
+    );
+    const disabled = store.prepareRequest(
+      request([{ role: 'user', content: 'stateless' }], { session_store: false }),
+    );
+
+    expect(reset.request.messages).toEqual([{ role: 'user', content: 'new conversation' }]);
+    expect(disabled.shouldStore).toBe(false);
+  });
+
+  it('reconstructs streamed tool calls for the next turn', async () => {
+    const store = new OpenAISessionStore();
+    const prepared = store.prepareRequest(request([{ role: 'user', content: 'check weather' }]));
+    const stream = of(
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"weather","arguments":"{\\"city\\":"}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"Samara\\"}"}}]}}]}\n\n',
+      'data: [DONE]\n\n',
+    );
+
+    await consume(store.recordStreamResponse(prepared, stream));
+    const next = store.prepareRequest(
+      request([{ role: 'tool', tool_call_id: 'call-1', content: 'sunny' }]),
+    );
+
+    expect(next.request.messages[1]).toEqual({
+      role: 'assistant',
+      content: '',
+      tool_calls: [
+        {
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'weather', arguments: '{"city":"Samara"}' },
+        },
+      ],
+    });
+  });
+
+  it('keeps stored history within the configured character budget', () => {
+    const store = new OpenAISessionStore({ maxHistoryChars: 120 });
+    const first = store.prepareRequest(
+      request([
+        { role: 'system', content: 'stable instructions' },
+        { role: 'user', content: 'x'.repeat(100) },
+      ]),
+    );
+    store.recordResponse(first, response('y'.repeat(100)));
+
+    const next = store.prepareRequest(request([{ role: 'user', content: 'latest' }]));
+    const serializedLength = next.request.messages.reduce(
+      (total, message) => total + JSON.stringify(message).length,
+      0,
+    );
+
+    expect(serializedLength).toBeLessThanOrEqual(120);
+    expect(next.request.messages).toContainEqual({
+      role: 'system',
+      content: 'stable instructions',
+    });
+    expect(next.request.messages.at(-1)).toEqual({ role: 'user', content: 'latest' });
+  });
+});
+
+async function consume(stream: Observable<string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    stream.subscribe({ complete: resolve, error: reject });
+  });
+}

--- a/src/tests/unit/openai-session-store.test.ts
+++ b/src/tests/unit/openai-session-store.test.ts
@@ -74,6 +74,50 @@ describe('OpenAISessionStore', () => {
     store.abandonRequest(second);
   });
 
+  it('does not duplicate bootstrap messages on subsequent turns', async () => {
+    const store = new OpenAISessionStore();
+    const bootstrap = { extra: { session_bootstrap: 'system instructions' } };
+    const first = await store.prepareRequest(
+      request([{ role: 'user', content: 'first question' }], bootstrap),
+    );
+    store.recordResponse(first, response('first answer'));
+
+    const second = await store.prepareRequest(
+      request([{ role: 'user', content: 'second question' }], bootstrap),
+    );
+
+    expect(second.request.messages).toEqual([
+      { role: 'system', content: 'system instructions' },
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+      { role: 'user', content: 'second question' },
+    ]);
+    store.abandonRequest(second);
+  });
+
+  it('matches resent messages regardless of object key order', async () => {
+    const store = new OpenAISessionStore();
+    const first = await store.prepareRequest(
+      request([{ role: 'user', content: 'first question' }]),
+    );
+    store.recordResponse(first, response('first answer'));
+
+    const second = await store.prepareRequest(
+      request([
+        { content: 'first question', role: 'user' },
+        { content: 'first answer', role: 'assistant' },
+        { content: 'second question', role: 'user' },
+      ]),
+    );
+
+    expect(second.request.messages).toEqual([
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+      { content: 'second question', role: 'user' },
+    ]);
+    store.abandonRequest(second);
+  });
+
   it('resets or disables history only through explicit session controls', async () => {
     const store = new OpenAISessionStore();
     const first = await store.prepareRequest(

--- a/src/tests/unit/proxy-retry-mock.test.ts
+++ b/src/tests/unit/proxy-retry-mock.test.ts
@@ -433,6 +433,39 @@ describe('ProxyService Empty Stream Retry Logic', () => {
     expect(internalPayload).not.toHaveProperty('sessionId');
   });
 
+  it('retains OpenAI chat history for an explicit session_id', async () => {
+    const service = new TestableProxyService();
+    mockAccountLeaseService.getNextToken.mockResolvedValue(createToken('acc-1'));
+    mockGeminiClient.generateInternal
+      .mockResolvedValueOnce({
+        candidates: [{ content: { parts: [{ text: 'first answer' }] }, finishReason: 'STOP' }],
+        usageMetadata: { totalTokenCount: 5 },
+      })
+      .mockResolvedValueOnce({
+        candidates: [{ content: { parts: [{ text: 'second answer' }] }, finishReason: 'STOP' }],
+        usageMetadata: { totalTokenCount: 5 },
+      });
+
+    await service.handleChatCompletions({
+      model: 'gemini-3-flash',
+      messages: [{ role: 'user', content: 'first question' }],
+      session_id: 'interview-1',
+    });
+    await service.handleChatCompletions({
+      model: 'gemini-3-flash',
+      messages: [{ role: 'user', content: 'second question' }],
+      session_id: 'interview-1',
+    });
+
+    const secondRequest = JSON.stringify(mockGeminiClient.generateInternal.mock.calls[1][0]);
+    expect(secondRequest).toContain('first question');
+    expect(secondRequest).toContain('first answer');
+    expect(secondRequest).toContain('second question');
+    expect(mockAccountLeaseService.getNextToken).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionKey: 'openai:interview-1' }),
+    );
+  });
+
   it('normalizes Gemini 3.1 preview alias to Gemini 3.1 Pro High for upstream', async () => {
     const service = new TestableProxyService();
     mockAccountLeaseService.getNextToken.mockResolvedValue(createToken('acc-1'));

--- a/src/tests/unit/proxy-retry-mock.test.ts
+++ b/src/tests/unit/proxy-retry-mock.test.ts
@@ -466,6 +466,33 @@ describe('ProxyService Empty Stream Retry Logic', () => {
     );
   });
 
+  it('releases an OpenAI session after request processing fails', async () => {
+    const service = new TestableProxyService();
+    mockAccountLeaseService.getNextToken
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(createToken('acc-1'));
+    mockGeminiClient.generateInternal.mockResolvedValue({
+      candidates: [{ content: { parts: [{ text: 'recovered' }] }, finishReason: 'STOP' }],
+      usageMetadata: { totalTokenCount: 5 },
+    });
+
+    await expect(
+      service.handleChatCompletions({
+        model: 'gemini-3-flash',
+        messages: [{ role: 'user', content: 'failed turn' }],
+        session_id: 'recoverable-session',
+      }),
+    ).rejects.toThrow('No available accounts');
+
+    await service.handleChatCompletions({
+      model: 'gemini-3-flash',
+      messages: [{ role: 'user', content: 'retry turn' }],
+      session_id: 'recoverable-session',
+    });
+
+    expect(mockGeminiClient.generateInternal).toHaveBeenCalledTimes(1);
+  });
+
   it('normalizes Gemini 3.1 preview alias to Gemini 3.1 Pro High for upstream', async () => {
     const service = new TestableProxyService();
     mockAccountLeaseService.getNextToken.mockResolvedValue(createToken('acc-1'));


### PR DESCRIPTION
## Summary

- add opt-in, process-local conversation history to the OpenAI-compatible Chat Completions endpoint
- allow clients to send only the newest turn while preserving user, assistant, and tool-call messages
- avoid duplicating history when a client resends the complete `messages` array
- support explicit reset, stateless requests, and one-time bootstrap context
- serialize concurrent turns within one session while keeping different sessions concurrent
- bound stored state by inactivity TTL, session count, and serialized character size

## Motivation

Some API clients need to retain context from the first request but cannot conveniently resend the full conversation on every Chat Completions call. This extension provides that behavior without changing the standard stateless default.

## API

History is enabled only when a request includes `session_id`. Optional controls are:

- `session_reset: true` to clear the session before the current turn
- `session_store: false` to keep the current request stateless
- `extra.session_bootstrap` or `extra.session_bootstrap_context` for initial system context
- `extra.session_bootstrap_messages` for initial OpenAI-compatible messages

## Concurrency and lifecycle

Requests sharing one `session_id` are processed in order so a later turn observes the preceding response. Streaming requests release the session when the stream completes, fails, or is cancelled. Different session IDs remain independent.

History is stored in memory, expires after six hours of inactivity, is limited to 64 sessions and 1,000,000 serialized characters per session, and is cleared when Antigravity Manager restarts.

## Security

The session ID is the sole history key. It is no longer written to request logs. Clients must use an unguessable ID and avoid sharing it across security boundaries; deployments exposed beyond a trusted interface should place authentication in front of the gateway.

## Compatibility

This is an Antigravity extension, not a standard Chat Completions field. Requests without `session_id` retain the existing stateless behavior.

## Validation

- `npm run type-check`
- targeted ESLint and Prettier checks
- 2 focused Vitest files, 41 tests
- coverage for incremental and full-history clients, tool calls, bounded history, same-session serialization, cross-session concurrency, abandoned requests, and failed streams

## Review status

The API is nonstandard and needs maintainer agreement on whether server-managed Chat Completions state belongs in the gateway. The unrelated required-check baseline cleanup was merged in #223; this branch intentionally does not duplicate that diff.
