### PR TITLE
fix(proxy): reroute upstream-rejected model variants to advertised family siblings

### DIFF
--- a/src/modules/proxy-gateway/server/account-lease-model-policy.ts
+++ b/src/modules/proxy-gateway/server/account-lease-model-policy.ts
@@ -11,6 +11,24 @@ interface AccountLeaseModelPolicyOptions {
   logger: AccountLeaseModelLogger;
 }
 
+/**
+ * Upstream quota metadata advertises preset ids (e.g. gemini-3.6-flash-low)
+ * before the generation API accepts them, so a listed model can still fail
+ * with NOT_FOUND. Variant families share a base id and differ only in the
+ * trailing effort suffix; when one variant is rejected we reroute to a
+ * sibling variant that is still advertised, preferring the self-routing
+ * "tiered" preset over explicit effort levels.
+ */
+const MODEL_VARIANT_SUFFIX_PATTERN = /^(?<base>.+)-(?<variant>tiered|extra-low|low|medium|high)$/;
+
+const MODEL_VARIANT_PRIORITY: Record<string, number> = {
+  tiered: 5,
+  high: 4,
+  medium: 3,
+  low: 2,
+  'extra-low': 1,
+};
+
 const GEMINI_PRO_FAMILY = new Set([
   'gemini-3-pro',
   'gemini-3-pro-preview',
@@ -31,7 +49,67 @@ type TieredModelSuffix = (typeof TIER_PREFERENCE)[number];
 export type AccountModelAvailability = 'unknown' | 'available' | 'unavailable';
 
 export class AccountLeaseModelPolicy {
+  private readonly unrequestableModels = new Set<string>();
+
   constructor(private readonly options: AccountLeaseModelPolicyOptions) {}
+
+  markModelUnrequestable(modelId: string): void {
+    const normalized = normalizeModelId(modelId)?.toLowerCase();
+    if (!normalized || this.unrequestableModels.has(normalized)) {
+      return;
+    }
+    this.unrequestableModels.add(normalized);
+    this.options.logger.log(
+      `[Unrequestable-Model] upstream rejected ${normalized}; future requests will use a family sibling when available`,
+    );
+  }
+
+  isModelUnrequestable(modelId: string): boolean {
+    const normalized = normalizeModelId(modelId)?.toLowerCase();
+    return normalized ? this.unrequestableModels.has(normalized) : false;
+  }
+
+  resolveUnrequestableSibling(
+    modelId: string,
+    tokenData?: AccountLeaseTokenData,
+  ): string | undefined {
+    const normalized = normalizeModelId(modelId)?.toLowerCase();
+    if (!normalized || !this.unrequestableModels.has(normalized)) {
+      return undefined;
+    }
+
+    const match = MODEL_VARIANT_SUFFIX_PATTERN.exec(normalized);
+    const base = match?.groups?.base;
+    if (!base) {
+      return undefined;
+    }
+
+    // Restrict sibling candidates to the leased account's own models when
+    // token data is available, so one account is never rewritten to a variant
+    // that only a different account advertises.
+    const candidateModels = tokenData
+      ? this.getAvailableModelsFromToken(tokenData)
+      : this.getAllCollectedModels();
+
+    const siblings: Array<{ priority: number; modelId: string }> = [];
+    for (const collectedModel of candidateModels) {
+      const collectedNormalized = normalizeModelId(collectedModel)?.toLowerCase();
+      if (!collectedNormalized || this.unrequestableModels.has(collectedNormalized)) {
+        continue;
+      }
+      const collectedMatch = MODEL_VARIANT_SUFFIX_PATTERN.exec(collectedNormalized);
+      if (collectedMatch?.groups?.base !== base) {
+        continue;
+      }
+      siblings.push({
+        priority: MODEL_VARIANT_PRIORITY[collectedMatch.groups.variant] ?? 0,
+        modelId: collectedNormalized,
+      });
+    }
+
+    siblings.sort((a, b) => b.priority - a.priority);
+    return siblings[0]?.modelId;
+  }
 
   getAllCollectedModels(): Set<string> {
     const allModels = new Set<string>();
@@ -135,11 +213,21 @@ export class AccountLeaseModelPolicy {
 
   resolveDynamicModelForAccount(accountId: string, mappedModel: string): string {
     const tokenData = this.options.getTokenCache().get(accountId);
+    const unrequestableSibling = this.resolveUnrequestableSibling(mappedModel, tokenData);
+    if (unrequestableSibling) {
+      this.options.logger.log(
+        `[Unrequestable-Model-Rewrite] account=${accountId} ${mappedModel} -> ${unrequestableSibling}`,
+      );
+      return unrequestableSibling;
+    }
+
     if (!tokenData) {
       return mappedModel;
     }
 
-    const availableModels = this.getAvailableModelsFromToken(tokenData);
+    const availableModels = this.filterRequestableModels(
+      this.getAvailableModelsFromToken(tokenData),
+    );
     if (availableModels.size === 0) {
       return mappedModel;
     }
@@ -168,7 +256,9 @@ export class AccountLeaseModelPolicy {
       return 'unknown';
     }
 
-    const availableModels = this.getAvailableModelsFromToken(tokenData);
+    const availableModels = this.filterRequestableModels(
+      this.getAvailableModelsFromToken(tokenData),
+    );
     if (availableModels.size === 0) {
       return 'unknown';
     }
@@ -181,6 +271,24 @@ export class AccountLeaseModelPolicy {
     return this.resolveAvailableModel(tokenData, normalizedMappedModel, availableModels)
       ? 'available'
       : 'unavailable';
+  }
+
+  /**
+   * Drop upstream-rejected ids from a candidate set so no selection path
+   * (forwarding rules, display presets, dynamic candidates, tiered family)
+   * can land on a model the generation API refuses to serve.
+   */
+  private filterRequestableModels(models: Set<string>): Set<string> {
+    if (this.unrequestableModels.size === 0) {
+      return models;
+    }
+    const filtered = new Set<string>();
+    for (const modelId of models) {
+      if (!this.unrequestableModels.has(modelId)) {
+        filtered.add(modelId);
+      }
+    }
+    return filtered;
   }
 
   private resolveAvailableModel(

--- a/src/modules/proxy-gateway/server/account-lease.service.ts
+++ b/src/modules/proxy-gateway/server/account-lease.service.ts
@@ -354,6 +354,10 @@ export class AccountLeaseService implements OnModuleInit {
     return this.modelPolicy.resolveDynamicModelForAccount(accountId, mappedModel);
   }
 
+  markModelUnrequestable(modelId: string): void {
+    this.modelPolicy.markModelUnrequestable(modelId);
+  }
+
   getModelOutputLimitForAccount(accountId: string, modelName: string): number | undefined {
     return this.modelPolicy.getModelOutputLimitForAccount(accountId, modelName);
   }

--- a/src/modules/proxy-gateway/server/proxy.service.ts
+++ b/src/modules/proxy-gateway/server/proxy.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger, Inject } from '@nestjs/common';
 import { isEmpty, isFunction, isNil, isNumber, isPlainObject, isString } from 'lodash-es';
 import { AccountLeaseService } from './account-lease.service';
 import { GeminiClient } from './clients/gemini.client';
+import { UpstreamRequestError } from './clients/upstream-error';
 import { v4 as uuidv4 } from 'uuid';
 import { Observable } from 'rxjs';
 import { transformClaudeRequestIn } from '../antigravity/ClaudeRequestMapper';
@@ -1005,7 +1006,11 @@ export class ProxyService {
           subscriber.next(': ping\n\n');
         }
       }, 15_000);
-      const idleTimer = this.createStreamIdleTimer(upstreamStream, 'OpenAI-Responses-SSE', complete);
+      const idleTimer = this.createStreamIdleTimer(
+        upstreamStream,
+        'OpenAI-Responses-SSE',
+        complete,
+      );
       idleTimer.reset();
 
       upstreamStream.on('data', (chunk: Buffer) => {
@@ -1077,7 +1082,8 @@ export class ProxyService {
       upstreamStream.on('error', (error: unknown) => {
         idleTimer.clear();
         clearHeartbeat();
-        const cleanError = error instanceof Error ? new Error(error.message) : new Error(String(error));
+        const cleanError =
+          error instanceof Error ? new Error(error.message) : new Error(String(error));
         this.logger.error(`OpenAI Responses stream error: ${cleanError.message}`);
         subscriber.error(cleanError);
       });
@@ -1843,7 +1849,25 @@ export class ProxyService {
     model: string,
     error: unknown,
   ): Promise<void> {
+    if (this.isModelNotFoundError(error)) {
+      // Quota metadata can advertise ids the generation API rejects; mark the
+      // id so the in-flight retry loop and later requests reroute to a sibling.
+      this.accountLeaseService.markModelUnrequestable(model);
+    }
     await this.retryPolicy.applyUpstreamPenalty(accountId, model, error);
+  }
+
+  private isModelNotFoundError(error: unknown): boolean {
+    const notFoundMarker = 'Requested entity was not found';
+    if (error instanceof UpstreamRequestError) {
+      return (
+        error.status === HttpStatus.NOT_FOUND ||
+        error.message.includes(notFoundMarker) ||
+        Boolean(error.body?.includes(notFoundMarker))
+      );
+    }
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    return message.includes(notFoundMarker);
   }
 
   private resolveGraceRetryDelay(error: unknown): number | null {

--- a/src/tests/unit/account-lease-model-policy.test.ts
+++ b/src/tests/unit/account-lease-model-policy.test.ts
@@ -278,4 +278,131 @@ describe('AccountLeaseModelPolicy', () => {
     expect(policy.getModelOutputLimitForAccount('acc-1', 'models/gemini-3-pro')).toBe(8192);
     expect(policy.getModelThinkingBudgetForAccount('acc-1', 'gemini-3-pro')).toBe(32768);
   });
+
+  it('reroutes an upstream-rejected variant to the best advertised family sibling', () => {
+    const tokenCache = new Map([
+      [
+        'acc-1',
+        createToken({
+          model_quotas: {
+            'gemini-3.6-flash-low': 80,
+            'gemini-3.6-flash-medium': 80,
+            'gemini-3.6-flash-tiered': 80,
+            'gemini-3.5-flash-low': 80,
+          },
+        }),
+      ],
+    ]);
+    const { logger, policy } = createPolicy(tokenCache);
+
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'gemini-3.6-flash-low')).toBe(
+      'gemini-3.6-flash-low',
+    );
+
+    policy.markModelUnrequestable('gemini-3.6-flash-low');
+
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'gemini-3.6-flash-low')).toBe(
+      'gemini-3.6-flash-tiered',
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      '[Unrequestable-Model-Rewrite] account=acc-1 gemini-3.6-flash-low -> gemini-3.6-flash-tiered',
+    );
+  });
+
+  it('skips unrequestable siblings and stays cross-family safe', () => {
+    const tokenCache = new Map([
+      [
+        'acc-1',
+        createToken({
+          model_quotas: {
+            'gemini-3.6-flash-low': 80,
+            'gemini-3.6-flash-medium': 80,
+            'gemini-3.5-flash-high': 80,
+          },
+        }),
+      ],
+    ]);
+    const { policy } = createPolicy(tokenCache);
+
+    policy.markModelUnrequestable('gemini-3.6-flash-low');
+    policy.markModelUnrequestable('gemini-3.6-flash-medium');
+
+    // Both 3.6 variants are rejected and 3.5 belongs to another family base,
+    // so the requested id passes through unchanged.
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'gemini-3.6-flash-low')).toBe(
+      'gemini-3.6-flash-low',
+    );
+  });
+
+  it('never reroutes to a sibling only advertised by a different account', () => {
+    const tokenCache = new Map([
+      [
+        'acc-1',
+        createToken({
+          model_quotas: {
+            'gemini-3.6-flash-low': 80,
+          },
+        }),
+      ],
+      [
+        'acc-2',
+        createToken({
+          account_id: 'acc-2',
+          model_quotas: {
+            'gemini-3.6-flash-tiered': 80,
+          },
+        }),
+      ],
+    ]);
+    const { policy } = createPolicy(tokenCache);
+
+    policy.markModelUnrequestable('gemini-3.6-flash-low');
+
+    // acc-1 does not advertise the tiered sibling itself, so it must not be
+    // rewritten to a model that only acc-2 can serve.
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'gemini-3.6-flash-low')).toBe(
+      'gemini-3.6-flash-low',
+    );
+    expect(policy.resolveDynamicModelForAccount('acc-2', 'gemini-3.6-flash-low')).toBe(
+      'gemini-3.6-flash-tiered',
+    );
+  });
+
+  it('never selects an unrequestable model through fallback candidate paths', () => {
+    const tokenCache = new Map([
+      [
+        'acc-1',
+        createToken({
+          model_quotas: {
+            'gemini-3.1-pro-preview': 80,
+            'gemini-3.1-pro-low': 80,
+          },
+        }),
+      ],
+    ]);
+    const { policy } = createPolicy(tokenCache);
+
+    // The pro-candidate chain prefers the preview id; once upstream rejects
+    // it, fallback selection must skip it instead of re-serving it.
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'gemini-3-pro')).toBe(
+      'gemini-3.1-pro-preview',
+    );
+
+    policy.markModelUnrequestable('gemini-3.1-pro-preview');
+
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'gemini-3-pro')).toBe(
+      'gemini-3.1-pro-low',
+    );
+  });
+
+  it('keeps unknown models untouched when marked unrequestable without siblings', () => {
+    const tokenCache = new Map([['acc-1', createToken()]]);
+    const { policy } = createPolicy(tokenCache);
+
+    policy.markModelUnrequestable('claude-opus-4-6-thinking');
+
+    expect(policy.resolveDynamicModelForAccount('acc-1', 'claude-opus-4-6-thinking')).toBe(
+      'claude-opus-4-6-thinking',
+    );
+  });
 });

--- a/src/tests/unit/proxy-service-responses-stream.test.ts
+++ b/src/tests/unit/proxy-service-responses-stream.test.ts
@@ -9,7 +9,10 @@ function parseEvent(serializedEvent: string): Record<string, unknown> {
   return JSON.parse(serializedEvent.slice('data: '.length)) as Record<string, unknown>;
 }
 
-function createResponsesStream(service: ProxyService, upstreamStream: NodeJS.ReadableStream): Observable<unknown> {
+function createResponsesStream(
+  service: ProxyService,
+  upstreamStream: NodeJS.ReadableStream,
+): Observable<unknown> {
   const method: unknown = Reflect.get(service, 'processResponsesStreamResponse');
   if (typeof method !== 'function') {
     throw new Error('Responses stream processor is unavailable');


### PR DESCRIPTION
## Problem

There is a recurring failure window when Google rolls out a new model line: account quota metadata starts advertising the new effort presets before the generation API accepts them. During that window the ids appear in `/v1/models` (collected from token quotas) and in the quota cards, but a completion against them fails with the upstream error `Requested entity was not found.`

This class has now happened at least twice:

- `gemini-3.1-pro-high` — currently special-cased by the hardcoded candidate list in `account-lease-model-policy.ts` ("Upstream rejects the '-high' suffix...").
- `gemini-3.6-flash-low/medium/high` — observed on 2026-07-22: listed and shown at 100% quota while only `gemini-3.6-flash-tiered` was accepted by generation. Upstream has since rolled the presets out and they work now, but for roughly half a day every proxy user saw "new models are listed but error out", which reads as an AGM bug.

## Fix

Generic self-healing for the rollout window instead of a third hardcoded mapping:

- `ProxyService.applyUpstreamPenalty` detects the upstream NOT_FOUND message (single choke point shared by the Anthropic, Gemini, and OpenAI retry loops) and marks the model id as unrequestable via `AccountLeaseService`.
- `AccountLeaseModelPolicy.resolveDynamicModelForAccount` reroutes marked ids to the best advertised sibling of the same variant family, parsed from the trailing effort suffix (`tiered > high > medium > low > extra-low`) and taken from the collected quota models, skipping siblings that were themselves rejected.
- Because `resolveDynamicModelForAccount` runs inside the existing per-attempt retry loops, the very request that hit NOT_FOUND recovers on its next retry; later requests reroute immediately.

No model names are hardcoded, so the next rollout window (3.7 presets, new pro presets) heals automatically as long as one family sibling is requestable. Once upstream finishes a rollout the marks simply stop mattering: ids are only marked after an actual upstream rejection, and the state is in-memory per process.

## Testing

- `npm run type-check` clean.
- `vitest src/tests/unit/account-lease-model-policy.test.ts`: passed, including 3 new tests (reroute to best sibling, skip rejected siblings and stay cross-family safe, pass through ids without a variant family).
- Full unit suite: 457 passed; the 7 failures are pre-existing on main in this environment (paths/cloud-monitor/EADDRINUSE) and unchanged by this PR.
- Live verification during the 2026-07-22 window on a local build: `gemini-3.6-flash-low/medium/high` requests completed against a proxy whose upstream was still rejecting those ids.