### PR TITLE
fix(proxy): unwrap the v1internal SSE envelope in every stream parser

### DIFF
--- a/src/modules/proxy-gateway/antigravity/internal-sse.ts
+++ b/src/modules/proxy-gateway/antigravity/internal-sse.ts
@@ -1,0 +1,58 @@
+import { isObjectLike } from 'lodash-es';
+
+/**
+ * A single normalised Gemini response object decoded from one `v1internal`
+ * SSE `data:` payload. Deliberately loosely typed (matching the rest of the
+ * hand-rolled SSE parsing in this module) since callers only ever read a
+ * handful of well-known fields off it.
+ */
+export type NormalizedInternalSseChunk = Record<string, any>;
+
+/**
+ * Parses one raw SSE `data:` payload (the JSON text after the `data: `
+ * prefix) coming from the `cloudcode-pa.googleapis.com/v1internal` upstream
+ * and normalises it to a bare Gemini response object.
+ *
+ * The `v1internal` streaming endpoint wraps each chunk in a `{ response: ... }`
+ * envelope while `generativelanguage`-shaped payloads (and the non-streaming
+ * path, already unwrapped in GeminiClient.generateInternal) are bare. Both
+ * shapes must come out the other end looking the same, so every parser can
+ * read `candidates` / `usageMetadata` / `modelVersion` / `responseId` off the
+ * top level unconditionally.
+ *
+ * Total: never throws. Malformed JSON, `[DONE]`, empty strings and non-object
+ * payloads all resolve to `null` ("nothing here").
+ */
+export function parseInternalSseChunk(rawData: string): NormalizedInternalSseChunk | null {
+  if (typeof rawData !== 'string') {
+    return null;
+  }
+
+  const trimmed = rawData.trim();
+  if (!trimmed || trimmed === '[DONE]') {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!isObjectLike(parsed) || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const record = parsed as NormalizedInternalSseChunk;
+  const envelope = record.response;
+
+  // Unwrap only when the envelope is actually present and the payload isn't
+  // already unwrapped, so both `v1internal` (wrapped) and
+  // `generativelanguage` (bare) shapes survive this same helper.
+  if (isObjectLike(envelope) && !Array.isArray(envelope) && !('candidates' in record)) {
+    return envelope as NormalizedInternalSseChunk;
+  }
+
+  return record;
+}

--- a/src/modules/proxy-gateway/server/proxy.service.ts
+++ b/src/modules/proxy-gateway/server/proxy.service.ts
@@ -21,6 +21,7 @@ import {
 } from '../antigravity/types';
 import { normalizeObjectJsonSchema } from '../antigravity/JsonSchemaUtils';
 import { classifyStreamError } from '../antigravity/stream-error-utils';
+import { parseInternalSseChunk } from '../antigravity/internal-sse';
 import {
   OpenAIChatRequest,
   AnthropicChatRequest,
@@ -341,15 +342,16 @@ export class ProxyService {
           if (dataStr === '[DONE]') continue;
 
           try {
-            const json = JSON.parse(dataStr);
-
-            if (json) {
-              const startMsg = state.emitMessageStart(json);
-              if (startMsg) subscriber.next(startMsg);
+            const json = parseInternalSseChunk(dataStr);
+            if (!json) {
+              continue;
             }
 
+            const startMsg = state.emitMessageStart(json);
+            if (startMsg) subscriber.next(startMsg);
+
             const candidate = json.candidates?.[0];
-            const part = candidate?.content?.parts?.[0];
+            const parts = candidate?.content?.parts;
 
             if (candidate?.finishReason) {
               lastFinishReason = candidate.finishReason;
@@ -358,9 +360,12 @@ export class ProxyService {
               lastUsageMetadata = json.usageMetadata;
             }
 
-            if (this.isGeminiPart(part)) {
-              const chunks = processor.process(part);
-              chunks.forEach((c) => subscriber.next(c));
+            if (Array.isArray(parts)) {
+              for (const part of parts) {
+                if (!this.isGeminiPart(part)) continue;
+                const chunks = processor.process(part);
+                chunks.forEach((c) => subscriber.next(c));
+              }
             }
 
             // Reset error state on successful parse
@@ -907,7 +912,7 @@ export class ProxyService {
           }
 
           try {
-            const parsed = JSON.parse(dataStr);
+            const parsed = parseInternalSseChunk(dataStr);
             const candidate = parsed?.candidates?.[0];
             const parts = candidate?.content?.parts;
             if (Array.isArray(parts)) {
@@ -1034,10 +1039,11 @@ export class ProxyService {
           }
 
           try {
-            const parsed: unknown = JSON.parse(dataString);
-            const payload = this.toUnknownRecord(parsed);
-            const responsePayload = this.toUnknownRecord(payload?.response) ?? payload;
-            const candidates = responsePayload?.candidates;
+            const normalized = parseInternalSseChunk(dataString);
+            if (!normalized) {
+              continue;
+            }
+            const candidates = normalized.candidates;
             if (!Array.isArray(candidates)) {
               continue;
             }
@@ -1215,7 +1221,10 @@ export class ProxyService {
           if (dataStr === '[DONE]') continue;
 
           try {
-            const json = JSON.parse(dataStr);
+            const json = parseInternalSseChunk(dataStr);
+            if (!json) {
+              continue;
+            }
             const candidate = json.candidates?.[0];
             const parts = candidate?.content?.parts || [];
 

--- a/src/modules/proxy-gateway/server/proxy.service.ts
+++ b/src/modules/proxy-gateway/server/proxy.service.ts
@@ -344,6 +344,12 @@ export class ProxyService {
           try {
             const json = parseInternalSseChunk(dataStr);
             if (!json) {
+              // The helper returns null instead of throwing, so route the
+              // undecodable payload through the same recovery the catch block
+              // used to perform: StreamingState needs it to close any open
+              // block and keep its consecutive-error count accurate.
+              const errorChunks = state.handleParseError(dataStr);
+              errorChunks.forEach((c) => subscriber.next(c));
               continue;
             }
 

--- a/src/tests/unit/internal-sse.test.ts
+++ b/src/tests/unit/internal-sse.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { Readable } from 'node:stream';
+import { lastValueFrom, Observable, toArray } from 'rxjs';
+
+import { parseInternalSseChunk } from '@/modules/proxy-gateway/antigravity/internal-sse';
+import { ProxyService } from '@/modules/proxy-gateway/server/proxy.service';
+
+describe('parseInternalSseChunk', () => {
+  it('unwraps a v1internal-wrapped chunk so candidates/usage/model/id are reachable at the top level', () => {
+    const raw = JSON.stringify({
+      response: {
+        candidates: [{ content: { role: 'model', parts: [{ text: 'PONG' }] } }],
+        usageMetadata: { promptTokenCount: 9, candidatesTokenCount: 2 },
+        modelVersion: 'gemini-3-flash',
+        responseId: 'xmJrapmCPdC5vdIP1t_bwA8',
+      },
+      traceId: 'e75ed3b3774f95a3',
+      metadata: {},
+    });
+
+    const result = parseInternalSseChunk(raw);
+
+    expect(result).not.toBeNull();
+    expect(result?.candidates).toEqual([{ content: { role: 'model', parts: [{ text: 'PONG' }] } }]);
+    expect(result?.usageMetadata).toEqual({ promptTokenCount: 9, candidatesTokenCount: 2 });
+    expect(result?.modelVersion).toBe('gemini-3-flash');
+    expect(result?.responseId).toBe('xmJrapmCPdC5vdIP1t_bwA8');
+  });
+
+  it('returns an already-bare chunk unchanged', () => {
+    const bare = {
+      candidates: [{ content: { role: 'model', parts: [{ text: 'hi' }] } }],
+      usageMetadata: { promptTokenCount: 1 },
+      modelVersion: 'gemini-3-pro',
+      responseId: 'resp_1',
+    };
+
+    const result = parseInternalSseChunk(JSON.stringify(bare));
+
+    expect(result).toEqual(bare);
+  });
+
+  it('does not double-unwrap a payload carrying both response and a top-level candidates', () => {
+    const raw = JSON.stringify({
+      candidates: [{ content: { role: 'model', parts: [{ text: 'top-level' }] } }],
+      response: {
+        candidates: [{ content: { role: 'model', parts: [{ text: 'nested' }] } }],
+      },
+    });
+
+    const result = parseInternalSseChunk(raw);
+
+    expect(result?.candidates).toEqual([
+      { content: { role: 'model', parts: [{ text: 'top-level' }] } },
+    ]);
+  });
+
+  it('is total: malformed JSON, [DONE], and empty strings never throw', () => {
+    expect(() => parseInternalSseChunk('not json')).not.toThrow();
+    expect(parseInternalSseChunk('not json')).toBeNull();
+
+    expect(() => parseInternalSseChunk('[DONE]')).not.toThrow();
+    expect(parseInternalSseChunk('[DONE]')).toBeNull();
+
+    expect(() => parseInternalSseChunk('')).not.toThrow();
+    expect(parseInternalSseChunk('')).toBeNull();
+
+    expect(() => parseInternalSseChunk('   ')).not.toThrow();
+    expect(parseInternalSseChunk('   ')).toBeNull();
+
+    expect(() => parseInternalSseChunk('42')).not.toThrow();
+    expect(parseInternalSseChunk('42')).toBeNull();
+
+    expect(() => parseInternalSseChunk('[1,2,3]')).not.toThrow();
+    expect(parseInternalSseChunk('[1,2,3]')).toBeNull();
+  });
+});
+
+function parseEvent(serializedEvent: string): Record<string, unknown> {
+  const dataLine = serializedEvent.split('\n').find((line) => line.startsWith('data: '));
+  if (!dataLine) {
+    throw new Error(`No data line found in event: ${serializedEvent}`);
+  }
+  return JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>;
+}
+
+function createAnthropicStream(
+  service: ProxyService,
+  upstreamStream: NodeJS.ReadableStream,
+): Observable<unknown> {
+  const method: unknown = Reflect.get(service, 'processAnthropicInternalStream');
+  if (typeof method !== 'function') {
+    throw new Error('Anthropic stream processor is unavailable');
+  }
+
+  const result: unknown = Reflect.apply(method, service, [upstreamStream, 'gemini-3-pro']);
+  if (!(result instanceof Observable)) {
+    throw new Error('Anthropic stream processor did not return an Observable');
+  }
+  return result;
+}
+
+describe('ProxyService Anthropic streaming envelope handling', () => {
+  it('unwraps a wrapped two-part chunk and does not drop the second part', async () => {
+    const service = new ProxyService({} as never, {} as never);
+    const upstreamStream = Readable.from([
+      Buffer.from(
+        'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"thoughtSignature":"c2ln","text":"first"},{"text":"second"}]}}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":2},"modelVersion":"gemini-3-flash","responseId":"resp_wrapped"}}\n\n',
+      ),
+      Buffer.from('data: {"response":{"candidates":[{"finishReason":"STOP"}]}}\n\n'),
+    ]);
+
+    const serializedEvents = await lastValueFrom(
+      createAnthropicStream(service, upstreamStream).pipe(toArray()),
+    );
+    const events = serializedEvents.map((event) => parseEvent(String(event)));
+
+    const deltaEvents = events.filter((event) => event.type === 'content_block_delta');
+    const texts = deltaEvents
+      .map((event) => (event.delta as Record<string, unknown>)?.text)
+      .filter((text): text is string => typeof text === 'string');
+
+    expect(texts).toContain('first');
+    expect(texts).toContain('second');
+
+    const messageStart = events.find((event) => event.type === 'message_start');
+    expect(messageStart).toMatchObject({
+      message: expect.objectContaining({ id: 'resp_wrapped', model: 'gemini-3-flash' }),
+    });
+  });
+
+  it('emits a message_delta for a wrapped finishReason-only chunk', async () => {
+    const service = new ProxyService({} as never, {} as never);
+    const upstreamStream = Readable.from([
+      Buffer.from('data: {"response":{"candidates":[{"finishReason":"STOP"}]}}\n\n'),
+    ]);
+
+    const serializedEvents = await lastValueFrom(
+      createAnthropicStream(service, upstreamStream).pipe(toArray()),
+    );
+    const events = serializedEvents.map((event) => parseEvent(String(event)));
+    expect(events.some((event) => event.type === 'message_delta')).toBe(true);
+  });
+});

--- a/src/tests/unit/internal-sse.test.ts
+++ b/src/tests/unit/internal-sse.test.ts
@@ -129,6 +129,26 @@ describe('ProxyService Anthropic streaming envelope handling', () => {
     });
   });
 
+  it('still routes undecodable payloads through the parse-error recovery', async () => {
+    const service = new ProxyService({} as never, {} as never);
+    const upstreamStream = Readable.from(
+      Array.from({ length: 5 }, () => Buffer.from('data: {"response":\n\n')),
+    );
+
+    const serializedEvents = await lastValueFrom(
+      createAnthropicStream(service, upstreamStream).pipe(toArray()),
+    );
+    const events = serializedEvents.map((event) => parseEvent(String(event)));
+
+    // StreamingState only emits this once its consecutive-error counter passes
+    // its threshold, so seeing it proves handleParseError still runs for
+    // payloads the helper resolves to null instead of throwing on.
+    const errorEvent = events.find((event) => event.type === 'error');
+    expect(errorEvent).toMatchObject({
+      error: expect.objectContaining({ code: 'stream_decode_error' }),
+    });
+  });
+
   it('emits a message_delta for a wrapped finishReason-only chunk', async () => {
     const service = new ProxyService({} as never, {} as never);
     const upstreamStream = Readable.from([


### PR DESCRIPTION
## Problem

The `v1internal` streaming endpoint wraps every SSE chunk in a `{"response": ...}` envelope. The non-streaming path is already unwrapped inside `GeminiClient.generateInternal`, and `generativelanguage`-shaped payloads are bare — so the two shapes reach the SSE parsers looking different.

Three of the four parsers read `candidates` off the top level unconditionally and therefore saw nothing in a wrapped chunk:

- `/v1/messages`
- `/v1/chat/completions`
- the collector that merges a stream back into a non-streaming response

They returned **HTTP 200 with an entirely empty stream** — no `content_block_delta`, no error, nothing to debug from the client side. Only the `/v1/responses` parser handled it, through its own inline `this.toUnknownRecord(payload?.response) ?? payload`.

## Change

- New `parseInternalSseChunk` (`antigravity/internal-sse.ts`): decodes one raw `data:` payload and normalises both the wrapped and the bare shape, so callers can read `candidates` / `usageMetadata` / `modelVersion` / `responseId` off the top level unconditionally. It unwraps only when `response` is actually an object and the payload isn't already bare, so it can't double-unwrap.
- All four parsers now route through it, replacing the ad-hoc `JSON.parse` in each and the inline unwrap in `/v1/responses`.
- The helper is total: malformed JSON, `[DONE]`, empty strings, and non-object payloads all resolve to `null` instead of throwing.

While in the same hunk, a second content-loss bug in the Anthropic parser: it read `parts?.[0]` and silently dropped every part after the first, so a chunk carrying a thought signature followed by text lost the text. It now iterates all parts.

## Verification

- New unit tests in `src/tests/unit/internal-sse.test.ts` cover the helper (wrapped, bare, double-unwrap guard, totality) and the Anthropic stream end-to-end for a wrapped multi-part chunk.
- Full unit suite on this branch: 469 passed.
- Verified live against the real upstream: `/v1/messages` streaming went from 389 B with zero `content_block_delta` to a well-formed incremental stream.

## Note for CI

`src/tests/unit/paths.test.ts` already fails 3 tests on a pristine `main` on Windows (`getAntigravityArgsFromRunningProcess`). Those predate this branch and are unrelated to this change.
