### PR TITLE
fix(proxy): forward tool declarations on the /v1beta passthrough

### DIFF
--- a/src/modules/proxy-gateway/server/interfaces/request-interfaces.ts
+++ b/src/modules/proxy-gateway/server/interfaces/request-interfaces.ts
@@ -1,3 +1,5 @@
+import type { GeminiToolDeclaration } from '../../antigravity/types';
+
 export interface OpenAIChatRequest {
   model: string;
   messages: OpenAIMessage[];
@@ -131,6 +133,7 @@ export interface GeminiRequest {
   contents: GeminiContent[];
   systemInstruction?: { parts: GeminiPart[] };
   generationConfig?: GeminiGenerationConfig;
+  tools?: GeminiToolDeclaration[];
 }
 
 export interface GeminiGenerationConfig {

--- a/src/modules/proxy-gateway/server/proxy.service.ts
+++ b/src/modules/proxy-gateway/server/proxy.service.ts
@@ -1518,6 +1518,9 @@ export class ProxyService {
     return {
       contents: request.contents,
       generationConfig: request.generationConfig,
+      // Forwarded verbatim: without this the `/v1beta` passthrough silently
+      // strips tool declarations, so the model can never call a tool.
+      tools: request.tools,
       systemInstruction: request.systemInstruction
         ? {
             parts: request.systemInstruction.parts

--- a/src/tests/unit/proxy-internal-request-mapping.test.ts
+++ b/src/tests/unit/proxy-internal-request-mapping.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { ProxyService } from '@/modules/proxy-gateway/server/proxy.service';
+import type { GeminiRequest } from '@/modules/proxy-gateway/server/interfaces/request-interfaces';
+import type { GeminiInternalRequest } from '@/modules/proxy-gateway/antigravity/types';
+
+function toInternalRequest(request: GeminiRequest): GeminiInternalRequest['request'] {
+  const service = new ProxyService({} as never, {} as never);
+  const method: unknown = Reflect.get(service, 'toInternalGeminiRequest');
+  if (typeof method !== 'function') {
+    throw new Error('toInternalGeminiRequest is unavailable');
+  }
+  return Reflect.apply(method, service, [request]) as GeminiInternalRequest['request'];
+}
+
+describe('toInternalGeminiRequest', () => {
+  it('forwards tool declarations so the /v1beta passthrough can call tools', () => {
+    const tools = [
+      {
+        functionDeclarations: [
+          {
+            name: 'get_weather',
+            description: 'Look up the weather for a city',
+            parameters: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+          },
+        ],
+      },
+    ];
+
+    const internal = toInternalRequest({
+      contents: [{ role: 'user', parts: [{ text: 'weather in Berlin?' }] }],
+      tools,
+    } as GeminiRequest);
+
+    expect(internal.tools).toEqual(tools);
+  });
+
+  it('leaves tools undefined when the caller sent none', () => {
+    const internal = toInternalRequest({
+      contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+    });
+
+    expect(internal.tools).toBeUndefined();
+  });
+
+  it('still maps contents, generationConfig and text-only systemInstruction', () => {
+    const internal = toInternalRequest({
+      contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+      generationConfig: { temperature: 0.25, maxOutputTokens: 64 },
+      systemInstruction: { parts: [{ text: 'be brief' }, { inlineData: {} } as never] },
+    } as GeminiRequest);
+
+    expect(internal.contents).toEqual([{ role: 'user', parts: [{ text: 'hi' }] }]);
+    expect(internal.generationConfig).toEqual({ temperature: 0.25, maxOutputTokens: 64 });
+    expect(internal.systemInstruction).toEqual({ parts: [{ text: 'be brief' }] });
+  });
+});


### PR DESCRIPTION
## Problem

`toInternalGeminiRequest` rebuilds the upstream request from scratch, copying only `contents`, `generationConfig` and `systemInstruction`:

```ts
return {
  contents: request.contents,
  generationConfig: request.generationConfig,
  systemInstruction: ...,
};
```

So any `tools` sent to `/v1beta/models/{model}:generateContent` (or `:streamGenerateContent`) are dropped before the request leaves the gateway.

The failure mode is quiet, which is what makes it worth fixing: the request still succeeds, the model answers in prose, and nothing in the response says the declarations were removed. From the caller's side it just looks like a model that stubbornly refuses to call a tool.

The internal request type (`antigravity/types.ts`) already declares `tools` — only the public `GeminiRequest` interface and this mapper were missing it.

## Change

- Declare `tools?: GeminiToolDeclaration[]` on the public `GeminiRequest`.
- Forward it verbatim in `toInternalGeminiRequest`.

## Verification

- New `src/tests/unit/proxy-internal-request-mapping.test.ts` asserts tools survive the mapping, stay `undefined` when the caller sent none, and that `contents` / `generationConfig` / text-only `systemInstruction` still map as before. Confirmed the tools assertion fails without the one-line fix.
- Full unit suite on this branch: 465 passed.
- Found by a contract test that drives a tool-call round-trip against all four surfaces: `/v1/messages`, `/v1/chat/completions` and `/v1/responses` completed the round-trip while `/v1beta` was the only one where the model never called the tool.

## Related, deliberately not changed here

`safetySettings` is declared on the internal type and is dropped by this same mapper. I left it alone to keep this change scoped to the path that has a failing test — happy to fold it in if you'd prefer.

## Note for CI

`src/tests/unit/paths.test.ts` already fails 3 tests on a pristine `main` on Windows. Those predate this branch and are unrelated.
