### PR TITLE
fix(proxy): stop sending sessionId in the v1internal envelope

### DIFF
--- a/src/modules/proxy-gateway/antigravity/ClaudeRequestMapper.ts
+++ b/src/modules/proxy-gateway/antigravity/ClaudeRequestMapper.ts
@@ -224,18 +224,27 @@ export function transformClaudeRequestIn(
     requestConfig,
     innerRequest: reorderedInnerRequest,
     projectId,
-    sessionId: claudeReq.metadata?.user_id,
     userAgent,
   });
 
   return body;
 }
 
+/**
+ * Builds the `v1internal` envelope.
+ *
+ * Deliberately carries no session identifier. An Anthropic client's advisory
+ * `metadata.user_id` used to be forwarded as `sessionId`, which the provider
+ * answers with `Invalid JSON payload received. Unknown name "sessionId":
+ * Cannot find field.`, failing the whole request. There is no accepted
+ * destination for it on this transport, and the field is advisory in
+ * Anthropic's own API, so it is dropped here rather than costing the caller
+ * the request.
+ */
 function buildInternalRequestBody(params: {
   requestConfig: ResolvedRequestConfig;
   innerRequest: GeminiInternalRequest['request'];
   projectId?: string;
-  sessionId?: string;
   userAgent?: string;
 }): GeminiInternalRequest {
   const normalizedProjectId = params.projectId?.trim();
@@ -248,7 +257,6 @@ function buildInternalRequestBody(params: {
     userAgent: params.userAgent?.trim() || buildUserAgent(discoveryVersion),
     requestType: isAgentRequest ? 'agent' : 'image_gen',
     ...(isAgentRequest ? { enabledCreditTypes: [...AGENT_CREDIT_TYPES] } : {}),
-    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
     requestId: createOfficialRequestId(),
   };
 

--- a/src/modules/proxy-gateway/antigravity/types.ts
+++ b/src/modules/proxy-gateway/antigravity/types.ts
@@ -300,7 +300,6 @@ export interface GeminiInternalRequest {
   model: string;
   userAgent: string;
   requestType?: string;
-  sessionId?: string;
   enabledCreditTypes?: string[];
 }
 

--- a/src/tests/unit/claude-request-mapper-cache-compatibility.test.ts
+++ b/src/tests/unit/claude-request-mapper-cache-compatibility.test.ts
@@ -248,7 +248,6 @@ describe('ClaudeRequestMapper cache compatibility', () => {
       'userAgent',
       'requestType',
       'enabledCreditTypes',
-      'sessionId',
       'requestId',
     ]);
   });

--- a/src/tests/unit/claude-request-mapper-session-id.test.ts
+++ b/src/tests/unit/claude-request-mapper-session-id.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformClaudeRequestIn } from '@/modules/proxy-gateway/antigravity/ClaudeRequestMapper';
+import type { ClaudeRequest } from '@/modules/proxy-gateway/antigravity/types';
+
+function createRequest(overrides: Partial<ClaudeRequest> = {}): ClaudeRequest {
+  return {
+    model: 'gemini-3-flash',
+    messages: [{ role: 'user', content: 'Help me fix the issue.' }],
+    ...overrides,
+  };
+}
+
+/**
+ * The provider rejects the whole request with
+ * `Invalid JSON payload received. Unknown name "sessionId": Cannot find field.`
+ * when the v1internal envelope carries one, so no client-supplied identifier
+ * may reach it. Reported in #227, where the Claude CLI sends `metadata.user_id`
+ * and every request fails.
+ */
+describe('ClaudeRequestMapper session identity', () => {
+  it('never puts a sessionId on the outgoing payload for metadata.user_id', () => {
+    const body = transformClaudeRequestIn(
+      createRequest({ metadata: { user_id: 'user_e5f1a0c2' } }),
+      'project-1',
+    );
+
+    expect(body).not.toHaveProperty('sessionId');
+    expect(JSON.stringify(body)).not.toContain('sessionId');
+  });
+
+  it('leaves the rest of the envelope untouched when metadata is present', () => {
+    const withMetadata = transformClaudeRequestIn(
+      createRequest({ metadata: { user_id: 'user_e5f1a0c2' } }),
+      'project-1',
+    );
+    const withoutMetadata = transformClaudeRequestIn(createRequest(), 'project-1');
+
+    expect(Object.keys(withMetadata)).toEqual(Object.keys(withoutMetadata));
+    expect(withMetadata.request).toEqual(withoutMetadata.request);
+    expect(withMetadata.model).toBe(withoutMetadata.model);
+  });
+});


### PR DESCRIPTION
Closes #227.

## The bug

`transformClaudeRequestIn` copies an Anthropic client's `metadata.user_id` into the `v1internal`
envelope as `sessionId`. That field does not exist on this transport, and the provider answers the
whole request with:

```
Invalid JSON payload received. Unknown name "sessionId": Cannot find field.
```

The Claude CLI sends `metadata.user_id`, so as reported in #227 the request fails before the model
is ever reached.

## The fix

Drop it. There is no accepted destination for a session identifier on this transport, and the field
is advisory in Anthropic's own API, so dropping it costs the caller nothing and saves the request.
`GeminiInternalRequest` no longer declares `sessionId` either, so it cannot come back by accident.

This does not touch session handling on our side: `extractAnthropicSessionKey` and
`extractOpenAISessionKey` in `ProxyService` still read the same fields to scope the signature store
per session. Only the outgoing payload changes.

## Where to look

`ClaudeRequestMapper.ts` is the whole fix; the rest is tests. The key-order assertion in
`claude-request-mapper-cache-compatibility.test.ts` had pinned `sessionId` as expected output, so it
moves with it.

## Verification

The new test was checked to fail without the fix, with exactly the two assertions the change is
about:

```
AssertionError: expected { project: 'project-1', ... } to not have property "sessionId"
```

`tsc --noEmit` clean, `npm run lint` 0 errors, Prettier clean on every changed file.

`npm test` gives 792 passed, 4 skipped, 2 failed. Both failures reproduce on `d5eac44` with an
untouched tree, so they are not from this change:

- `paths.test.ts > should prioritize --user-data-dir from the running target process`, because the
  fixture reads the host's real Antigravity config instead of its own. I have a fix for this and
  can send it separately.
- `gateway-start.test.ts > returns the actual configured port when startup succeeds`.

Both are Windows, Node 24.15.
