### PR TITLE
fix(opencode): open the keyring on first use, not during import

### DIFF
--- a/src/modules/proxy-gateway/opencode-sync/opencode-native-credential-store.ts
+++ b/src/modules/proxy-gateway/opencode-sync/opencode-native-credential-store.ts
@@ -38,8 +38,13 @@ export class OpenCodeNativeCredentialStore implements OpenCodeCredentialStore {
   }
 
   delete(): void {
+    // Resolved before the try: opening the keyring used to fail loudly in the
+    // constructor, and a failure to open it is not the same thing as a
+    // credential that was already gone.
+    const entry = this.entry;
+
     try {
-      this.entry.deleteCredential();
+      entry.deleteCredential();
     } catch {
       // Revoking a key that does not exist is idempotent.
     }

--- a/src/modules/proxy-gateway/opencode-sync/opencode-native-credential-store.ts
+++ b/src/modules/proxy-gateway/opencode-sync/opencode-native-credential-store.ts
@@ -6,11 +6,28 @@ const OPEN_CODE_KEYRING_SERVICE = 'Antigravity Manager';
 const OPEN_CODE_KEYRING_ACCOUNT = 'opencode-proxy-key';
 
 export class OpenCodeNativeCredentialStore implements OpenCodeCredentialStore {
-  private readonly entry = Entry.withTarget(
-    OPEN_CODE_KEYRING_TARGET,
-    OPEN_CODE_KEYRING_SERVICE,
-    OPEN_CODE_KEYRING_ACCOUNT,
-  );
+  private cachedEntry: Entry | null = null;
+
+  /**
+   * Opened on first use, not in a field initializer.
+   *
+   * `opencode-credentials.ts` constructs this store at module scope and
+   * `proxy.guard.ts` imports it, so a field initializer reached the OS keyring
+   * during import: every test that pulled in the guard opened a credential
+   * store before its first line ran, and failed wherever no keyring is
+   * available.
+   */
+  private get entry(): Entry {
+    if (!this.cachedEntry) {
+      this.cachedEntry = Entry.withTarget(
+        OPEN_CODE_KEYRING_TARGET,
+        OPEN_CODE_KEYRING_SERVICE,
+        OPEN_CODE_KEYRING_ACCOUNT,
+      );
+    }
+
+    return this.cachedEntry;
+  }
 
   read(): string | null {
     return this.entry.getPassword();

--- a/src/tests/unit/antigravity-client-cache.test.ts
+++ b/src/tests/unit/antigravity-client-cache.test.ts
@@ -11,6 +11,17 @@ vi.mock('@/shared/logging/logger', () => ({
 }));
 
 const originalPlatform = process.platform;
+
+/**
+ * The cases below pin Windows path semantics and touch the real filesystem, so
+ * they only mean anything on Windows. Elsewhere `path.win32.join` turns the
+ * fixture into one relative name full of backslashes: `mkdir -p` then creates a
+ * single directory under the working tree instead of a nested path, the code
+ * under test finds nothing, and the leftovers are never cleaned up because
+ * `afterEach` removes the temp directory rather than the working tree.
+ */
+const itOnWindows = originalPlatform === 'win32' ? it : it.skip;
+
 const originalLocalAppData = process.env.LOCALAPPDATA;
 const originalAppData = process.env.APPDATA;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
@@ -42,7 +53,7 @@ describe('Antigravity client cache', () => {
     vi.restoreAllMocks();
   });
 
-  it('lists existing Windows IDE cache paths in priority order', async () => {
+  itOnWindows('lists existing Windows IDE cache paths in priority order', async () => {
     const localIdeCache = path.win32.join(process.env.LOCALAPPDATA!, 'Antigravity IDE', 'Cache');
     const roamingIdeCache = path.win32.join(process.env.APPDATA!, 'Antigravity IDE', 'Cache');
     fs.mkdirSync(localIdeCache, { recursive: true });
@@ -92,7 +103,7 @@ describe('Antigravity client cache', () => {
     ]);
   });
 
-  it('removes an existing cache directory and reports the freed bytes', async () => {
+  itOnWindows('removes an existing cache directory and reports the freed bytes', async () => {
     const localIdeCache = path.win32.join(process.env.LOCALAPPDATA!, 'Antigravity IDE', 'Cache');
     const nestedCache = path.win32.join(localIdeCache, 'Code Cache');
     fs.mkdirSync(nestedCache, { recursive: true });
@@ -111,7 +122,7 @@ describe('Antigravity client cache', () => {
     expect(fs.existsSync(localIdeCache)).toBe(false);
   });
 
-  it('continues clearing later paths when one cache directory fails', async () => {
+  itOnWindows('continues clearing later paths when one cache directory fails', async () => {
     const localClassicCache = path.win32.join(process.env.LOCALAPPDATA!, 'Antigravity', 'Cache');
     const localIdeCache = path.win32.join(process.env.LOCALAPPDATA!, 'Antigravity IDE', 'Cache');
     fs.mkdirSync(localClassicCache, { recursive: true });

--- a/src/tests/unit/gateway-start.test.ts
+++ b/src/tests/unit/gateway-start.test.ts
@@ -26,9 +26,12 @@ vi.mock('@/shared/logging/logger', () => ({
   logger: mockLogger,
 }));
 
-vi.mock('@/modules/proxy-gateway/server/openai-responses-websocket.server', () => ({
-  attachOpenAIResponsesWebSocketServer: mockAttachResponsesWebSocketServer,
-}));
+vi.mock(
+  '@/modules/proxy-gateway/server/modules/openai/responses/openai-responses-websocket.server',
+  () => ({
+    attachOpenAIResponsesWebSocketServer: mockAttachResponsesWebSocketServer,
+  }),
+);
 
 describe('gateway server startup', () => {
   beforeEach(() => {

--- a/src/tests/unit/opencode-native-credential-store.test.ts
+++ b/src/tests/unit/opencode-native-credential-store.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const keyringMocks = vi.hoisted(() => ({
+  withTarget: vi.fn(),
+  getPassword: vi.fn(() => 'stored-key'),
+  setPassword: vi.fn(),
+  deleteCredential: vi.fn(),
+}));
+
+vi.mock('@napi-rs/keyring', () => ({
+  Entry: {
+    withTarget: keyringMocks.withTarget,
+  },
+}));
+
+import { OpenCodeNativeCredentialStore } from '@/modules/proxy-gateway/opencode-sync/opencode-native-credential-store';
+
+describe('OpenCodeNativeCredentialStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    keyringMocks.withTarget.mockReturnValue({
+      getPassword: keyringMocks.getPassword,
+      setPassword: keyringMocks.setPassword,
+      deleteCredential: keyringMocks.deleteCredential,
+    });
+  });
+
+  /**
+   * `opencode-credentials.ts` constructs the store at module scope and
+   * `proxy.guard.ts` imports it, so opening the keyring in a field initializer
+   * reaches the OS credential store during import. Anywhere without a keyring,
+   * that fails every test that pulls in the guard.
+   */
+  it('does not open the keyring while being constructed', () => {
+    new OpenCodeNativeCredentialStore();
+
+    expect(keyringMocks.withTarget).not.toHaveBeenCalled();
+  });
+
+  it('opens the keyring on first use and reuses it afterwards', () => {
+    const store = new OpenCodeNativeCredentialStore();
+
+    expect(store.read()).toBe('stored-key');
+    store.write('next-key');
+
+    expect(keyringMocks.withTarget).toHaveBeenCalledOnce();
+    expect(keyringMocks.withTarget).toHaveBeenCalledWith(
+      'antigravity-manager:opencode',
+      'Antigravity Manager',
+      'opencode-proxy-key',
+    );
+    expect(keyringMocks.setPassword).toHaveBeenCalledWith('next-key');
+  });
+
+  it('treats deleting an absent credential as done', () => {
+    keyringMocks.deleteCredential.mockImplementationOnce(() => {
+      throw new Error('No matching entry found in secure storage');
+    });
+    const store = new OpenCodeNativeCredentialStore();
+
+    expect(() => store.delete()).not.toThrow();
+  });
+});

--- a/src/tests/unit/opencode-native-credential-store.test.ts
+++ b/src/tests/unit/opencode-native-credential-store.test.ts
@@ -60,4 +60,18 @@ describe('OpenCodeNativeCredentialStore', () => {
 
     expect(() => store.delete()).not.toThrow();
   });
+
+  /**
+   * Opening the keyring used to fail in the constructor, where nothing hid it.
+   * Now that it happens on first use, `delete()` must not fold that failure
+   * into the idempotent "already gone" case.
+   */
+  it('still reports a keyring that cannot be opened at all', () => {
+    keyringMocks.withTarget.mockImplementation(() => {
+      throw new Error("Value of 'target' is invalid: unknown key");
+    });
+    const store = new OpenCodeNativeCredentialStore();
+
+    expect(() => store.delete()).toThrow("Value of 'target' is invalid: unknown key");
+  });
 });


### PR DESCRIPTION
`tests-unit` has been red on `main` since `854a43dc` on 2026-08-05, last green at `e63d8da6`. Two
independent causes, both fixed here. Measured on Ubuntu 24.04, Node 24.16, at `d5eac44` and with
these two commits applied:

```
d5eac44          7 test files failed, 749 passed
with these four  1 test file failed,  790 passed
```

The one left is `paths.test.ts`, and only on my machine: it passes on your runner. Three causes
follow, each with its own commit.

## Why it fails

`OpenCodeNativeCredentialStore` builds its `Entry` in a field initializer, and
`opencode-credentials.ts` constructs the store at module scope:

```ts
export const openCodeCredentialService = new OpenCodeCredentialService(
  new OpenCodeNativeCredentialStore(),
);
```

`proxy.guard.ts` imports that module, so every test that pulls in the guard reaches the OS
credential store before its first line runs. Where no keyring is available the constructor throws
`Value of 'target' is invalid: unknown key`, and the whole file collapses. On the run for `d5eac44`
that is five files: `appError`, `gateway-context-cache-status`, `gateway-start`,
`gemini-controller.integration` and `proxy-controller.integration`.

The entry is opened on first read, write or delete, then cached. Ordinary use is unchanged, and
importing the module touches nothing. A test pins the laziness and was checked to fail without it,
so the import-time regression cannot come back unnoticed.

## Second cause: a mock left behind by the migration

Fixing the first one uncovered the second. `beb9f62` moved
`openai-responses-websocket.server.ts` into `modules/openai/responses/` and updated the import in
`main.ts`, but the `vi.mock` call in `gateway-start.test.ts` kept the old specifier. Mocking a
path nothing imports is silently inert, so the real `attachOpenAIResponsesWebSocketServer` ran
against the test's `getHttpServer: () => ({})` and failed with `server.on is not a function`.

That one is not platform-specific. It reproduces on Windows too; CI never showed it because the
file collapsed earlier, on the keyring import.

## Third cause: a Windows fixture running on a Linux box

`antigravity-client-cache.test.ts` pins `process.platform` to `win32` and builds its fixture paths
with `path.win32.join`, but the filesystem calls run for real. Off Windows that collapses into a
single relative name full of backslashes, so `mkdir -p` creates one directory in the working tree
instead of a nested path, the code under test finds nothing, and the leftovers survive because
`afterEach` removes the temp directory rather than the tree. One Linux run left 41 such entries
behind, visible in `git status`.

The three cases that touch the filesystem now skip off Windows. The three platform ordering checks
are pure string comparisons and keep running everywhere. If you would rather see them run for real
on Linux, that means mocking `fs` for the suite, and I did not want to make that call for you.

## Review feedback

Copilot pointed out that moving the entry behind a lazy getter put its construction inside the
`try` in `delete()`, so a keyring that could not be opened at all was swallowed by the catch meant
for a credential that was already gone. Correct, and fixed in `45695c3`: the entry is resolved
before the `try`, with a test pinning the difference.
