### PR TITLE
refactor(proxy-gateway): own shared services through module metadata

### DIFF
--- a/src/modules/proxy-gateway/server/common/base-proxy.service.ts
+++ b/src/modules/proxy-gateway/server/common/base-proxy.service.ts
@@ -36,14 +36,18 @@ export abstract class BaseProxyService {
   private readonly streamIdleTimeoutMs = 300_000;
   protected readonly generationConstraints: GenerationConstraintsService;
   protected readonly retryPolicy: ProxyRetryService;
-  protected readonly modelRoutingPolicy = new ModelRoutingService();
+  protected readonly modelRoutingPolicy: ModelRoutingService;
 
   constructor(
     protected readonly accountLeaseService: AccountLeaseService,
     protected readonly geminiClient: GeminiClient,
+    generationConstraints: GenerationConstraintsService,
+    retryPolicy: ProxyRetryService,
+    modelRoutingPolicy: ModelRoutingService,
   ) {
-    this.generationConstraints = new GenerationConstraintsService(this.accountLeaseService);
-    this.retryPolicy = new ProxyRetryService(this.accountLeaseService, this.logger);
+    this.generationConstraints = generationConstraints;
+    this.retryPolicy = retryPolicy;
+    this.modelRoutingPolicy = modelRoutingPolicy;
   }
 
   protected createOfficialRequestId(): string {

--- a/src/modules/proxy-gateway/server/modules/account-lease/account-lease.module.ts
+++ b/src/modules/proxy-gateway/server/modules/account-lease/account-lease.module.ts
@@ -6,11 +6,16 @@ import {
   cloudAccountStoreAdapter,
   googleAccountLeaseUpstreamAdapter,
 } from './interfaces/account-lease-adapters';
+import { RateLimitTrackerService } from '../../shared/services/rate-limit-tracker.service';
 import { AccountLeaseService } from './account-lease.service';
 
 @Module({
   providers: [
     AccountLeaseService,
+    // Owns the lockout and failure-count maps. Lives here rather than in the shared module
+    // because `AccountLeaseService` is its only writer, and putting it in `shared/` would
+    // make `SharedServicesModule` and `AccountLeaseModule` import each other.
+    RateLimitTrackerService,
     {
       provide: ACCOUNT_LEASE_ACCOUNT_STORE,
       useValue: cloudAccountStoreAdapter,
@@ -20,6 +25,6 @@ import { AccountLeaseService } from './account-lease.service';
       useValue: googleAccountLeaseUpstreamAdapter,
     },
   ],
-  exports: [AccountLeaseService],
+  exports: [AccountLeaseService, RateLimitTrackerService],
 })
 export class AccountLeaseModule {}

--- a/src/modules/proxy-gateway/server/modules/account-lease/account-lease.service.ts
+++ b/src/modules/proxy-gateway/server/modules/account-lease/account-lease.service.ts
@@ -58,6 +58,11 @@ export class AccountLeaseService implements OnModuleInit {
     @Optional()
     @Inject(ACCOUNT_LEASE_UPSTREAM)
     private readonly upstream: AccountLeaseUpstream = googleAccountLeaseUpstreamAdapter,
+    // Under Nest the module provides the singleton and the token wins. The default only
+    // applies when the service is constructed directly, which today is tests alone.
+    @Optional()
+    @Inject(RateLimitTrackerService)
+    private readonly rateLimitTrackerService: RateLimitTrackerService = new RateLimitTrackerService(),
   ) {
     this.quotaRefreshPolicy = new AccountLeaseQuotaRefreshPolicy({
       accountStore: this.accountStore,
@@ -105,6 +110,7 @@ export class AccountLeaseService implements OnModuleInit {
       setPreciseLockoutFromCachedQuota: (accountId, reason, model) =>
         this.quotaRefreshPolicy.setPreciseLockoutFromCachedQuota(accountId, reason, model),
       logger: this.logger,
+      rateLimitTracker: this.rateLimitTrackerService,
     });
   }
 

--- a/src/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy.ts
+++ b/src/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy.ts
@@ -36,13 +36,20 @@ interface AccountLeaseLimitPolicyOptions {
     model?: string,
   ) => boolean;
   logger: AccountLeaseLimitLogger;
+  /**
+   * Owned by `AccountLeaseModule` and handed in, not constructed here. The tracker holds the
+   * lockout and failure-count maps, so a second instance would split rate-limit state.
+   */
+  rateLimitTracker: RateLimitTrackerService;
 }
 
 export class AccountLeaseLimitPolicy {
   private readonly accountCooldowns = new Map<string, number>();
-  private readonly rateLimitTracker = new RateLimitTrackerService();
+  private readonly rateLimitTracker: RateLimitTrackerService;
 
-  constructor(private readonly options: AccountLeaseLimitPolicyOptions) {}
+  constructor(private readonly options: AccountLeaseLimitPolicyOptions) {
+    this.rateLimitTracker = options.rateLimitTracker;
+  }
 
   getAccountCooldowns(): Map<string, number> {
     return this.accountCooldowns;

--- a/src/modules/proxy-gateway/server/modules/anthropic/anthropic.module.ts
+++ b/src/modules/proxy-gateway/server/modules/anthropic/anthropic.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { ProxyGuard } from '../../guards/proxy.guard';
+import { SharedServicesModule } from '../../shared/shared-services.module';
 import { AccountLeaseModule } from '../account-lease/account-lease.module';
 import { GeminiModule } from '../gemini/gemini.module';
 import { AnthropicController } from './anthropic.controller';
 import { AnthropicService } from './anthropic.service';
 
 @Module({
-  imports: [AccountLeaseModule, GeminiModule],
+  imports: [AccountLeaseModule, GeminiModule, SharedServicesModule],
   controllers: [AnthropicController],
   providers: [AnthropicService, ProxyGuard],
   exports: [AnthropicService],

--- a/src/modules/proxy-gateway/server/modules/anthropic/anthropic.service.ts
+++ b/src/modules/proxy-gateway/server/modules/anthropic/anthropic.service.ts
@@ -26,14 +26,26 @@ import {
   rebindAnthropicModelVariant,
 } from '@/modules/proxy-gateway/server/shared/services/model-variant-request.service';
 import { BaseProxyService } from '@/modules/proxy-gateway/server/common/base-proxy.service';
+import { GenerationConstraintsService } from '@/modules/proxy-gateway/server/shared/services/generation-constraints.service';
+import { ModelRoutingService } from '@/modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '@/modules/proxy-gateway/server/shared/services/proxy-retry.service';
 
 @Injectable()
 export class AnthropicService extends BaseProxyService {
   constructor(
     @Inject(AccountLeaseService) accountLeaseService: AccountLeaseService,
     @Inject(GeminiClient) geminiClient: GeminiClient,
+    @Inject(GenerationConstraintsService) generationConstraints: GenerationConstraintsService,
+    @Inject(ProxyRetryService) retryPolicy: ProxyRetryService,
+    @Inject(ModelRoutingService) modelRoutingPolicy: ModelRoutingService,
   ) {
-    super(accountLeaseService, geminiClient);
+    super(
+      accountLeaseService,
+      geminiClient,
+      generationConstraints,
+      retryPolicy,
+      modelRoutingPolicy,
+    );
   }
   async handleAnthropicMessages(
     request: AnthropicChatRequest,

--- a/src/modules/proxy-gateway/server/modules/gemini/gemini.module.ts
+++ b/src/modules/proxy-gateway/server/modules/gemini/gemini.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { ProxyGuard } from '../../guards/proxy.guard';
+import { SharedServicesModule } from '../../shared/shared-services.module';
 import { AccountLeaseModule } from '../account-lease/account-lease.module';
 import { GeminiClient } from './gemini-client.service';
 import { GeminiController } from './gemini.controller';
 import { GeminiService } from './gemini.service';
 
 @Module({
-  imports: [AccountLeaseModule],
+  imports: [AccountLeaseModule, SharedServicesModule],
   controllers: [GeminiController],
   providers: [GeminiClient, GeminiService, ProxyGuard],
   exports: [GeminiClient, GeminiService],

--- a/src/modules/proxy-gateway/server/modules/gemini/gemini.service.ts
+++ b/src/modules/proxy-gateway/server/modules/gemini/gemini.service.ts
@@ -10,14 +10,26 @@ import {
 } from '@/modules/proxy-gateway/server/common/interfaces/request-interfaces';
 import { resolveRequestUserAgent } from '@/modules/proxy-gateway/server/common/utils/request-user-agent';
 import { BaseProxyService } from '@/modules/proxy-gateway/server/common/base-proxy.service';
+import { GenerationConstraintsService } from '@/modules/proxy-gateway/server/shared/services/generation-constraints.service';
+import { ModelRoutingService } from '@/modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '@/modules/proxy-gateway/server/shared/services/proxy-retry.service';
 
 @Injectable()
 export class GeminiService extends BaseProxyService {
   constructor(
     @Inject(AccountLeaseService) accountLeaseService: AccountLeaseService,
     @Inject(GeminiClient) geminiClient: GeminiClient,
+    @Inject(GenerationConstraintsService) generationConstraints: GenerationConstraintsService,
+    @Inject(ProxyRetryService) retryPolicy: ProxyRetryService,
+    @Inject(ModelRoutingService) modelRoutingPolicy: ModelRoutingService,
   ) {
-    super(accountLeaseService, geminiClient);
+    super(
+      accountLeaseService,
+      geminiClient,
+      generationConstraints,
+      retryPolicy,
+      modelRoutingPolicy,
+    );
   }
 
   // --- OpenAI / Universal Handlers ---

--- a/src/modules/proxy-gateway/server/modules/openai/openai.module.ts
+++ b/src/modules/proxy-gateway/server/modules/openai/openai.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 
 import { CloudMonitorService } from '@/modules/cloud-account/services/CloudMonitorService';
 import { ProxyGuard } from '../../guards/proxy.guard';
+import { SharedServicesModule } from '../../shared/shared-services.module';
 import { AccountLeaseModule } from '../account-lease/account-lease.module';
 import { GeminiModule } from '../gemini/gemini.module';
 import { IMAGE_QUOTA_REFRESH, OpenAIController } from './openai.controller';
 import { OpenAIService } from './openai.service';
 
 @Module({
-  imports: [AccountLeaseModule, GeminiModule],
+  imports: [AccountLeaseModule, GeminiModule, SharedServicesModule],
   controllers: [OpenAIController],
   providers: [
     OpenAIService,

--- a/src/modules/proxy-gateway/server/modules/openai/openai.service.ts
+++ b/src/modules/proxy-gateway/server/modules/openai/openai.service.ts
@@ -50,6 +50,9 @@ import {
 } from '@/modules/proxy-gateway/server/shared/services/model-variant-request.service';
 import { safeStringifyPacket } from '@/shared/security/sensitiveDataMasking';
 import { BaseProxyService } from '@/modules/proxy-gateway/server/common/base-proxy.service';
+import { GenerationConstraintsService } from '@/modules/proxy-gateway/server/shared/services/generation-constraints.service';
+import { ModelRoutingService } from '@/modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '@/modules/proxy-gateway/server/shared/services/proxy-retry.service';
 import { GeminiService } from '@/modules/proxy-gateway/server/modules/gemini/gemini.service';
 
 export type OpenAIOutputProtocol = 'chat-completions' | 'responses';
@@ -60,8 +63,17 @@ export class OpenAIService extends BaseProxyService {
     @Inject(AccountLeaseService) accountLeaseService: AccountLeaseService,
     @Inject(GeminiClient) geminiClient: GeminiClient,
     @Inject(GeminiService) private readonly geminiService: GeminiService,
+    @Inject(GenerationConstraintsService) generationConstraints: GenerationConstraintsService,
+    @Inject(ProxyRetryService) retryPolicy: ProxyRetryService,
+    @Inject(ModelRoutingService) modelRoutingPolicy: ModelRoutingService,
   ) {
-    super(accountLeaseService, geminiClient);
+    super(
+      accountLeaseService,
+      geminiClient,
+      generationConstraints,
+      retryPolicy,
+      modelRoutingPolicy,
+    );
   }
 
   async handleChatCompletions(

--- a/src/modules/proxy-gateway/server/shared/services/generation-constraints.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/generation-constraints.service.ts
@@ -1,6 +1,13 @@
+import { Inject, Injectable } from '@nestjs/common';
 import { isNumber, isString } from 'lodash-es';
 import { getMaxOutputTokens, getThinkingBudget } from '../../../antigravity/ModelSpecs';
 import type { GeminiInternalRequest } from '../../../antigravity/types';
+
+/**
+ * Injection token for the account-side capability reader. A token rather than the concrete
+ * `AccountLeaseService` keeps `shared/` free of an import back into `modules/account-lease/`.
+ */
+export const PROXY_MODEL_CAPABILITY_READER = 'PROXY_MODEL_CAPABILITY_READER';
 
 export interface ProxyModelCapabilityReader {
   getModelOutputLimitForAccount(accountId: string, modelName: string): number | undefined;
@@ -13,8 +20,12 @@ export interface RegisteredGenerationConstraints {
   includeThoughts: boolean;
 }
 
+@Injectable()
 export class GenerationConstraintsService {
-  constructor(private readonly modelCapabilities: ProxyModelCapabilityReader) {}
+  constructor(
+    @Inject(PROXY_MODEL_CAPABILITY_READER)
+    private readonly modelCapabilities: ProxyModelCapabilityReader,
+  ) {}
 
   applyInternalGenerationConstraints(
     body: GeminiInternalRequest,

--- a/src/modules/proxy-gateway/server/shared/services/model-routing.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/model-routing.service.ts
@@ -1,6 +1,8 @@
+import { Injectable } from '@nestjs/common';
 import { getServerConfig } from '../../../../../server/server-config';
 import { normalizeGeminiModelAlias, resolveModelRoute } from '../../../antigravity/ModelMapping';
 
+@Injectable()
 export class ModelRoutingService {
   normalizeGeminiModel(model: string): string {
     return model.replace(/^models\//i, '');

--- a/src/modules/proxy-gateway/server/shared/services/proxy-retry.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/proxy-retry.service.ts
@@ -1,3 +1,4 @@
+import { Inject, Injectable } from '@nestjs/common';
 import { isString } from 'lodash-es';
 import { CloudAccount } from '@/modules/cloud-account/types';
 import { calculateRetryDelay, sleep } from '../../../antigravity/retry-utils';
@@ -35,10 +36,18 @@ export interface ProxyRetryAccountLeaseService {
   markModelSuccess(accountIdOrEmail: string, model: string): void;
 }
 
-interface ProxyRetryLogger {
+export interface ProxyRetryLogger {
   log(message: string): void;
   warn(message: string): void;
 }
+
+/**
+ * Injection tokens. Tokens rather than the concrete `AccountLeaseService` and `Logger` keep
+ * `shared/` free of an import back into `modules/account-lease/`, and keep the retry service
+ * testable with a plain fake.
+ */
+export const PROXY_RETRY_ACCOUNT_LEASE = 'PROXY_RETRY_ACCOUNT_LEASE';
+export const PROXY_RETRY_LOGGER = 'PROXY_RETRY_LOGGER';
 
 export interface ProxyUpstreamFailureClassification {
   retry: boolean;
@@ -46,9 +55,12 @@ export interface ProxyUpstreamFailureClassification {
   markAsRateLimited: boolean;
 }
 
+@Injectable()
 export class ProxyRetryService {
   constructor(
+    @Inject(PROXY_RETRY_ACCOUNT_LEASE)
     private readonly accountLeaseService: ProxyRetryAccountLeaseService,
+    @Inject(PROXY_RETRY_LOGGER)
     private readonly logger: ProxyRetryLogger,
   ) {}
 

--- a/src/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@nestjs/common';
 import { isEmpty, isNumber, isObjectLike, isString } from 'lodash-es';
 import { getQuotaModelFamilyId } from '@/modules/cloud-account/utils/quota-model-families';
 
@@ -244,6 +245,7 @@ export function shouldGraceRetry(delayMs: number): boolean {
   return delayMs > 0 && delayMs <= GRACE_RETRY_WINDOW_MS;
 }
 
+@Injectable()
 export class RateLimitTrackerService {
   private readonly lockoutByKey = new Map<string, RateLimitInfo>();
   private readonly failureCounts = new Map<string, FailureCountEntry>();

--- a/src/modules/proxy-gateway/server/shared/shared-services.module.ts
+++ b/src/modules/proxy-gateway/server/shared/shared-services.module.ts
@@ -1,0 +1,46 @@
+import { Logger, Module } from '@nestjs/common';
+
+import { AccountLeaseModule } from '../modules/account-lease/account-lease.module';
+import { AccountLeaseService } from '../modules/account-lease/account-lease.service';
+import {
+  GenerationConstraintsService,
+  PROXY_MODEL_CAPABILITY_READER,
+} from './services/generation-constraints.service';
+import { ModelRoutingService } from './services/model-routing.service';
+import {
+  PROXY_RETRY_ACCOUNT_LEASE,
+  PROXY_RETRY_LOGGER,
+  ProxyRetryService,
+} from './services/proxy-retry.service';
+
+/**
+ * Owns the services that every protocol surface shares. Before this module each of
+ * `OpenAIService`, `AnthropicService` and `GeminiService` built its own copies in
+ * `BaseProxyService`, which `server/README.md` rule 5 forbids and which the protocol split
+ * turned from one instance into three.
+ *
+ * The interface-typed dependencies arrive by token so that `shared/` never imports
+ * `AccountLeaseService` outside this module, keeping the two directions of the graph apart.
+ */
+@Module({
+  imports: [AccountLeaseModule],
+  providers: [
+    ModelRoutingService,
+    GenerationConstraintsService,
+    ProxyRetryService,
+    {
+      provide: PROXY_MODEL_CAPABILITY_READER,
+      useExisting: AccountLeaseService,
+    },
+    {
+      provide: PROXY_RETRY_ACCOUNT_LEASE,
+      useExisting: AccountLeaseService,
+    },
+    {
+      provide: PROXY_RETRY_LOGGER,
+      useValue: new Logger('ProxyRetryService'),
+    },
+  ],
+  exports: [ModelRoutingService, GenerationConstraintsService, ProxyRetryService],
+})
+export class SharedServicesModule {}

--- a/src/tests/scripts/project-id-request-validation.ts
+++ b/src/tests/scripts/project-id-request-validation.ts
@@ -3,6 +3,9 @@ import { isEmpty, isString } from 'lodash-es';
 
 import { transformClaudeRequestIn } from '../../modules/proxy-gateway/antigravity/ClaudeRequestMapper';
 import { AnthropicService } from '../../modules/proxy-gateway/server/modules/anthropic/anthropic.service';
+import { GenerationConstraintsService } from '@/modules/proxy-gateway/server/shared/services/generation-constraints.service';
+import { ModelRoutingService } from '@/modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '@/modules/proxy-gateway/server/shared/services/proxy-retry.service';
 import { GeminiService as ProxyService } from '../../modules/proxy-gateway/server/modules/gemini/gemini.service';
 import { AccountLeaseService } from '../../modules/proxy-gateway/server/modules/account-lease/account-lease.service';
 
@@ -22,7 +25,13 @@ const mockGeminiClient: any = {
 
 class TestableProxyService extends ProxyService {
   constructor() {
-    super(mockAccountLease, mockGeminiClient);
+    super(
+      mockAccountLease,
+      mockGeminiClient,
+      new GenerationConstraintsService(mockAccountLease as never),
+      new ProxyRetryService(mockAccountLease as never, { log: () => {}, warn: () => {} }),
+      new ModelRoutingService(),
+    );
   }
 
   public createGeminiInternal(
@@ -256,7 +265,13 @@ async function validateRuntimeAnthropicRequestFromRealAccountLease(): Promise<vo
   };
 
   try {
-    const service = new AnthropicService(AccountLeaseProxy as any, mockGeminiClient as any);
+    const service = new AnthropicService(
+      AccountLeaseProxy as any,
+      mockGeminiClient as any,
+      new GenerationConstraintsService(AccountLeaseProxy as never),
+      new ProxyRetryService(AccountLeaseProxy as never, { log: () => {}, warn: () => {} }),
+      new ModelRoutingService(),
+    );
     await service.handleAnthropicMessages({
       model: 'claude-sonnet-4-5',
       stream: false,

--- a/src/tests/unit/account-lease-limit-policy.test.ts
+++ b/src/tests/unit/account-lease-limit-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AccountLeaseLimitPolicy } from '@/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy';
-import { RateLimitReason } from '@/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service';
+import {
+  RateLimitReason,
+  RateLimitTrackerService,
+} from '@/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service';
 
 function createPolicy() {
   const logger = {
@@ -17,6 +20,7 @@ function createPolicy() {
     refreshRealtimeQuotaAndReconcileLimit,
     setPreciseLockoutFromCachedQuota,
     logger,
+    rateLimitTracker: new RateLimitTrackerService(),
   });
 
   return {

--- a/src/tests/unit/internal-sse.test.ts
+++ b/src/tests/unit/internal-sse.test.ts
@@ -110,7 +110,13 @@ function createAnthropicStream(
 
 describe('ProxyService Anthropic streaming envelope handling', () => {
   it('unwraps a wrapped two-part chunk and does not drop the second part', async () => {
-    const service = new ProxyService({} as never, {} as never);
+    const service = new ProxyService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
     const upstreamStream = Readable.from([
       Buffer.from(
         'data: {"response":{"candidates":[{"content":{"role":"model","parts":[{"thoughtSignature":"c2ln","text":"first"},{"text":"second"}]}}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":2},"modelVersion":"gemini-3-flash","responseId":"resp_wrapped"}}\n\n',
@@ -138,7 +144,13 @@ describe('ProxyService Anthropic streaming envelope handling', () => {
   });
 
   it('still routes undecodable payloads through the parse-error recovery', async () => {
-    const service = new ProxyService({} as never, {} as never);
+    const service = new ProxyService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
     const upstreamStream = Readable.from(
       Array.from({ length: 5 }, () => Buffer.from('data: {"response":\n\n')),
     );
@@ -158,7 +170,13 @@ describe('ProxyService Anthropic streaming envelope handling', () => {
   });
 
   it('emits a message_delta for a wrapped finishReason-only chunk', async () => {
-    const service = new ProxyService({} as never, {} as never);
+    const service = new ProxyService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
     const upstreamStream = Readable.from([
       Buffer.from('data: {"response":{"candidates":[{"finishReason":"STOP"}]}}\n\n'),
     ]);

--- a/src/tests/unit/proxy-di-state-ownership.test.ts
+++ b/src/tests/unit/proxy-di-state-ownership.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SELF_DECLARED_DEPS_METADATA } from '@nestjs/common/constants';
+import { NestFactory } from '@nestjs/core';
+
+vi.mock('ps-list', () => ({
+  default: vi.fn().mockResolvedValue([]),
+}));
+
+import { ProxyModule } from '@/modules/proxy-gateway/server/proxy.module';
+import { AccountLeaseService } from '@/modules/proxy-gateway/server/modules/account-lease/account-lease.service';
+import { AnthropicService } from '@/modules/proxy-gateway/server/modules/anthropic/anthropic.service';
+import { GeminiService } from '@/modules/proxy-gateway/server/modules/gemini/gemini.service';
+import { OpenAIService } from '@/modules/proxy-gateway/server/modules/openai/openai.service';
+import { GenerationConstraintsService } from '@/modules/proxy-gateway/server/shared/services/generation-constraints.service';
+import { ModelRoutingService } from '@/modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '@/modules/proxy-gateway/server/shared/services/proxy-retry.service';
+import {
+  RateLimitReason,
+  RateLimitTrackerService,
+} from '@/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service';
+
+/**
+ * `server/README.md` rules 2 and 5: shared services and account-lease stores are provided
+ * through module metadata and must not be instantiated twice, or in-memory locks and
+ * rate-limit state split.
+ *
+ * Nothing pinned that before. It mattered more after the protocol split, because
+ * `BaseProxyService` went from one subclass to three, so every service it built for itself
+ * existed three times over.
+ */
+describe('proxy gateway state ownership', () => {
+  async function createContext() {
+    return NestFactory.createApplicationContext(ProxyModule, { logger: false });
+  }
+
+  it('hands every protocol service the same shared instances', async () => {
+    const context = await createContext();
+
+    const generationConstraints = context.get(GenerationConstraintsService);
+    const retryPolicy = context.get(ProxyRetryService);
+    const modelRouting = context.get(ModelRoutingService);
+
+    // Same token resolves to one instance, not one per asking module.
+    expect(context.get(GenerationConstraintsService)).toBe(generationConstraints);
+    expect(context.get(ProxyRetryService)).toBe(retryPolicy);
+    expect(context.get(ModelRoutingService)).toBe(modelRouting);
+
+    for (const service of [
+      context.get(OpenAIService),
+      context.get(AnthropicService),
+      context.get(GeminiService),
+    ]) {
+      expect(Reflect.get(service, 'generationConstraints')).toBe(generationConstraints);
+      expect(Reflect.get(service, 'retryPolicy')).toBe(retryPolicy);
+      expect(Reflect.get(service, 'modelRoutingPolicy')).toBe(modelRouting);
+    }
+
+    await context.close();
+  });
+
+  it('keeps rate-limit state visible between the account lease and the container tracker', async () => {
+    const context = await createContext();
+
+    const accountLease = context.get(AccountLeaseService);
+    const tracker = context.get(RateLimitTrackerService);
+
+    // The lease service reaches its tracker through the limit policy. Before this change the
+    // policy built its own, so these were two objects and neither could see the other.
+    const limitPolicy = Reflect.get(accountLease, 'limitPolicy') as {
+      getRateLimitTracker(): RateLimitTrackerService;
+    };
+    expect(limitPolicy.getRateLimitTracker()).toBe(tracker);
+
+    // And the state really is shared, not just the reference shape.
+    expect(tracker.isRateLimited('acc-di-probe')).toBe(false);
+    limitPolicy
+      .getRateLimitTracker()
+      .setLockoutUntilIso(
+        'acc-di-probe',
+        new Date(Date.now() + 60_000).toISOString(),
+        RateLimitReason.RateLimitExceeded,
+      );
+    expect(tracker.isRateLimited('acc-di-probe')).toBe(true);
+    tracker.clear('acc-di-probe');
+
+    await context.close();
+  });
+
+  it('reuses one account lease across the three protocol services', async () => {
+    const context = await createContext();
+
+    const accountLease = context.get(AccountLeaseService);
+    for (const service of [
+      context.get(OpenAIService),
+      context.get(AnthropicService),
+      context.get(GeminiService),
+    ]) {
+      expect(Reflect.get(service, 'accountLeaseService')).toBe(accountLease);
+    }
+
+    await context.close();
+  });
+});
+
+describe('proxy gateway explicit injection', () => {
+  // Type-based injection is erased by minification in the packaged build: the parameter
+  // resolves to `undefined` at runtime while the whole suite still passes. An explicit
+  // token is what survives, so read Nest's own metadata rather than checking that the
+  // fields happen to be populated, which stays true under type-based wiring too.
+  function indicesWithExplicitToken(
+    target: abstract new (...args: never[]) => unknown,
+  ): Set<number> {
+    const declared = (Reflect.getMetadata(SELF_DECLARED_DEPS_METADATA, target) ?? []) as Array<{
+      index: number;
+    }>;
+    return new Set(declared.map((dependency) => dependency.index));
+  }
+
+  it.each([
+    ['OpenAIService', OpenAIService],
+    ['AnthropicService', AnthropicService],
+    ['GeminiService', GeminiService],
+    ['GenerationConstraintsService', GenerationConstraintsService],
+    ['ProxyRetryService', ProxyRetryService],
+  ])('names a token on every constructor parameter of %s', (name, target) => {
+    const withToken = indicesWithExplicitToken(target);
+    const parameterCount = target.length;
+
+    expect(parameterCount).toBeGreaterThan(0);
+    for (let index = 0; index < parameterCount; index += 1) {
+      expect(withToken.has(index), `${name} parameter ${index} has no @Inject token`).toBe(true);
+    }
+  });
+});

--- a/src/tests/unit/proxy-internal-request-mapping.test.ts
+++ b/src/tests/unit/proxy-internal-request-mapping.test.ts
@@ -5,7 +5,7 @@ import type { GeminiRequest } from '@/modules/proxy-gateway/server/common/interf
 import type { GeminiInternalRequest } from '@/modules/proxy-gateway/antigravity/types';
 
 function toInternalRequest(request: GeminiRequest): GeminiInternalRequest['request'] {
-  const service = new ProxyService({} as never, {} as never);
+  const service = new ProxyService({} as never, {} as never, {} as never, {} as never, {} as never);
   const method: unknown = Reflect.get(service, 'toInternalGeminiRequest');
   if (typeof method !== 'function') {
     throw new Error('toInternalGeminiRequest is unavailable');

--- a/src/tests/unit/proxy-parity-fixtures.test.ts
+++ b/src/tests/unit/proxy-parity-fixtures.test.ts
@@ -18,7 +18,14 @@ const mockGeminiClient = { streamGenerateInternal: vi.fn(), generateInternal: vi
 
 class TestableProxyService extends ProxyService {
   constructor() {
-    super(mockAccountLeaseService as any, mockGeminiClient as any, {} as any);
+    super(
+      mockAccountLeaseService as any,
+      mockGeminiClient as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
   }
 
   public toAnthropic(request: any): any {

--- a/src/tests/unit/proxy-retry-mock.test.ts
+++ b/src/tests/unit/proxy-retry-mock.test.ts
@@ -10,6 +10,23 @@ import { GeminiClient } from '../../modules/proxy-gateway/server/modules/gemini/
 import { setServerConfig } from '../../server/server-config';
 import { DEFAULT_APP_CONFIG, ProxyConfig } from '@/modules/config/types';
 import { SignatureStore } from '@/modules/proxy-gateway/antigravity/SignatureStore';
+import { GenerationConstraintsService } from '../../modules/proxy-gateway/server/shared/services/generation-constraints.service';
+import { ModelRoutingService } from '../../modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '../../modules/proxy-gateway/server/shared/services/proxy-retry.service';
+
+// The three services the protocol services used to build for themselves. Real instances:
+// these tests drive the retry path, so a placeholder would change what is under test.
+function sharedProxyServices(): [
+  GenerationConstraintsService,
+  ProxyRetryService,
+  ModelRoutingService,
+] {
+  return [
+    new GenerationConstraintsService(mockAccountLeaseService as any),
+    new ProxyRetryService(mockAccountLeaseService as any, { log: () => {}, warn: () => {} }),
+    new ModelRoutingService(),
+  ];
+}
 
 // Mock dependencies
 const mockAccountLeaseService = {
@@ -47,7 +64,12 @@ class TestableOpenAIService extends OpenAIService {
     super(
       mockAccountLeaseService as any,
       mockGeminiClient as any,
-      new GeminiService(mockAccountLeaseService as any, mockGeminiClient as any),
+      new GeminiService(
+        mockAccountLeaseService as any,
+        mockGeminiClient as any,
+        ...sharedProxyServices(),
+      ),
+      ...sharedProxyServices(),
     );
   }
 
@@ -58,7 +80,7 @@ class TestableOpenAIService extends OpenAIService {
 
 class TestableAnthropicService extends AnthropicService {
   constructor() {
-    super(mockAccountLeaseService as any, mockGeminiClient as any);
+    super(mockAccountLeaseService as any, mockGeminiClient as any, ...sharedProxyServices());
   }
 
   public testProcessStream(stream: any, model: string = 'model'): Observable<string> {
@@ -68,7 +90,7 @@ class TestableAnthropicService extends AnthropicService {
 
 class TestableGeminiService extends GeminiService {
   constructor() {
-    super(mockAccountLeaseService as any, mockGeminiClient as any);
+    super(mockAccountLeaseService as any, mockGeminiClient as any, ...sharedProxyServices());
   }
 
   public testPassthroughStream(stream: any): Observable<string> {

--- a/src/tests/unit/proxy-service-responses-stream.test.ts
+++ b/src/tests/unit/proxy-service-responses-stream.test.ts
@@ -33,7 +33,14 @@ describe('ProxyService Responses streaming', () => {
   it('keeps an otherwise idle Responses connection alive with SSE comments', async () => {
     vi.useFakeTimers();
     try {
-      const service = new ProxyService({} as never, {} as never, {} as never);
+      const service = new ProxyService(
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+      );
       const upstreamStream = new PassThrough();
       const events: string[] = [];
       const subscription = createResponsesStream(service, upstreamStream).subscribe((event) => {
@@ -50,7 +57,14 @@ describe('ProxyService Responses streaming', () => {
   });
 
   it('converts nested Gemini SSE payloads into Responses events', async () => {
-    const service = new ProxyService({} as never, {} as never, {} as never);
+    const service = new ProxyService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
     const upstreamStream = Readable.from([
       Buffer.from('data: not json\n\n'),
       Buffer.from(


### PR DESCRIPTION
First stage from the series in #239, rebased onto `1b6c555`.

**Narrower than I described in the issue.** There I said stage 1 would cover all five `new` sites plus an owner for the model availability store. This covers four of the five. `proxyModelAvailabilityStore` is left alone on purpose: it is imported directly by `shared/services/proxy-retry.service.ts`, `proxy-gateway/ipc/router.ts` and `cloud-account/ipc/handler.ts`, and the last two sit outside the Nest container, so giving it an owner is a different change with a different blast radius. It gets its own PR.

### What this does

`server/README.md` rule 5 asks for services to be provided through module metadata, and rule 2 warns that a second instance of a policy or store splits in-memory locks and rate-limit state.

Your protocol split made this sharper without touching the offending lines. `BaseProxyService` went from one subclass to three, so `ModelRoutingService`, `GenerationConstraintsService` and `ProxyRetryService` are now built three times instead of once.

I want to be accurate about how bad that is rather than oversell it: all three are stateless, so today this costs allocations and nothing else. `RateLimitTrackerService` does hold state, two maps of lockouts and failure counts, but it is single because `AccountLeaseService` happens to be a singleton. That is an accident of the current graph, not a guarantee, and nothing in the suite would notice if it stopped holding.

So:

- `SharedServicesModule` provides the three stateless services. The interface-typed dependencies arrive by token (`PROXY_MODEL_CAPABILITY_READER`, `PROXY_RETRY_ACCOUNT_LEASE`, `PROXY_RETRY_LOGGER`) so that `shared/` still does not import `AccountLeaseService` and the two module directions do not form a cycle.
- `RateLimitTrackerService` moves into `AccountLeaseModule`, whose service is its only writer, and is handed to the limit policy instead of being constructed inside it.
- `BaseProxyService` receives the three services instead of building them per subclass.

### One externally visible difference

`ProxyRetryService` used to be handed the logger of whichever protocol service built it, so its lines appeared under `OpenAIService`, `AnthropicService` or `GeminiService`. It now logs under its own name. No API contract changes, but log output does.

### Tests

`src/tests/unit/proxy-di-state-ownership.test.ts`, four assertions: one instance per token; the same instances inside all three protocol services; the lease service and the container share one rate-limit tracker, verified by writing through one reference and reading through the other; every injected field resolves.

One caveat worth stating plainly: this test cannot fail on the parent commit. There `GenerationConstraintsService` is not provided at all, so `context.get` throws rather than asserting. It pins the new invariant, it does not reproduce an old bug.

The explicit-token rule is worth keeping for a reason beyond hygiene. Under minification in the packaged build, type-based injection resolves to `undefined` at runtime while the whole suite still passes.

Existing tests that construct a protocol service directly needed the new arguments. Where a test only used placeholders I added placeholders; in `proxy-retry-mock.test.ts` and `project-id-request-validation.ts`, which drive the retry path, I passed real instances so the tests still exercise what they claim to.

### Verification

Run on this commit, with dependencies installed from this branch's lockfile:

```
tsc --noEmit      clean
eslint .          0 errors, 8 warnings (same 8 as the parent)
prettier --check  clean on every file this commit touches
vitest run        802 passed, 4 skipped, 1 failed
```

The one failure is `paths.test.ts`, and it is not from this change. It reproduces on `1b6c555` with an untouched tree, because the fixture reads the Antigravity IDE installed on the developer machine. Your CI is green on the parent for the same reason: that path does not exist on the runner. I have a small fix for it and will send it separately.

`prettier --check` also reports five files this commit does not touch: `AGENTS.md`, `OpenAIUsageMapper.ts`, `OpenAIResponsesResponseMapper.ts`, `proxy.guard.ts` and `explicit-context-cache.store.ts`. They are byte-identical to the parent here, so they are not from this branch. Happy to fix them in a separate PR if you want that.

If the boundary or the abstraction here looks wrong to you, I would rather change it now than after the next stages land on top.
