### PR TITLE
test: isolate IDE process cache fixture from host Antigravity config

### DIFF
--- a/src/tests/unit/paths.test.ts
+++ b/src/tests/unit/paths.test.ts
@@ -178,12 +178,23 @@ describe('Path Utilities', () => {
       },
     ];
 
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const userDataDir = p.resolve('D:\\Profiles\\AG IDE');
+    const expectedDbPath = p.join(userDataDir, 'User', 'globalStorage', 'state.vscdb');
+    const expectedStoragePath = p.join(userDataDir, 'User', 'globalStorage', 'storage.json');
+
+    vi.spyOn(fs, 'existsSync').mockImplementation((candidatePath) => {
+      const normalizedPath = String(candidatePath);
+      return (
+        normalizedPath === userDataDir ||
+        normalizedPath === expectedDbPath ||
+        normalizedPath === expectedStoragePath
+      );
+    });
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('');
     findProcessMock.mockResolvedValue(runningProcesses);
 
     const paths = await import('../../shared/platform/paths');
     await paths.refreshAntigravityProcessCache('ide');
-    const userDataDir = p.resolve('D:\\Profiles\\AG IDE');
 
     expect(paths.getAntigravityArgsFromRunningProcess('ide')).toEqual([
       [


### PR DESCRIPTION
`paths.test.ts` passes on your CI and fails for anyone developing on Windows with Antigravity IDE actually installed. The fixture stubs `fs.existsSync` to return `true` for every path, so the real installation is discovered alongside the fake profile and the assertion picks up an extra entry:

```
'C:\Program Files\Antigravity IDE\Antigravity IDE.exe'
```

On the CI runner that path does not exist, which is why the suite is green there and this has gone unnoticed.

The fix narrows the stub to the three paths the case is actually about, and stubs `readFileSync` so the discovery does not read whatever happens to be on the host.

Measured on `1b6c555` with an otherwise untouched tree:

```
before   1 failed | 24 passed (25)
after    25 passed (25)
```

No change on CI, since the test already passes there. `prettier --check` clean.

Found while preparing #242, sent separately because it has nothing to do with that change.
