### PR TITLE
chore(format): bring main back under its own prettier gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,8 @@ Do not add tests for values that are statically defined.
 Do not create small helper methods that are referenced only once.
 
 ### Avoid large modules:
+
 - Prefer adding new modules instead of growing existing ones.
-- Target  modules under 500 LoC, excluding tests.
+- Target modules under 500 LoC, excluding tests.
 - If a file exceeds roughly 800 LoC, add new functionality in a new module instead of extending the existing file unless there is a strong documented reason not to.
 - When extracting code from a large module, move the related tests and module/type docs toward the new implementation so the invariants stay close to the code that owns them.

--- a/src/modules/proxy-gateway/antigravity/OpenAIResponsesResponseMapper.ts
+++ b/src/modules/proxy-gateway/antigravity/OpenAIResponsesResponseMapper.ts
@@ -1,4 +1,7 @@
-import type { OpenAIChatResponse, OpenAIToolCall } from '../server/common/interfaces/request-interfaces';
+import type {
+  OpenAIChatResponse,
+  OpenAIToolCall,
+} from '../server/common/interfaces/request-interfaces';
 import { optimizeApplyPatch, validateApplyPatchV4A } from './ApplyPatchPreflight';
 import { extractCustomToolInput, isCustomToolCall } from './CustomToolCall';
 import { toOpenAIResponsesUsage } from './OpenAIUsageMapper';

--- a/src/modules/proxy-gateway/antigravity/OpenAIUsageMapper.ts
+++ b/src/modules/proxy-gateway/antigravity/OpenAIUsageMapper.ts
@@ -1,5 +1,8 @@
 import type { Usage } from './types';
-import type { GeminiUsageMetadata, OpenAIUsage } from '../server/common/interfaces/request-interfaces';
+import type {
+  GeminiUsageMetadata,
+  OpenAIUsage,
+} from '../server/common/interfaces/request-interfaces';
 
 export interface OpenAIResponsesUsage {
   input_tokens: number;

--- a/src/modules/proxy-gateway/server/guards/proxy.guard.ts
+++ b/src/modules/proxy-gateway/server/guards/proxy.guard.ts
@@ -6,11 +6,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { getServerConfig } from '../../../../server/server-config';
-import {
-  extractApiKeyToken,
-  hasConfiguredApiKey,
-  RequestHeaders,
-} from './api-key-auth.util';
+import { extractApiKeyToken, hasConfiguredApiKey, RequestHeaders } from './api-key-auth.util';
 import { openCodeCredentialService } from '../../opencode-sync/opencode-credentials';
 
 @Injectable()

--- a/src/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.store.ts
+++ b/src/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.store.ts
@@ -193,10 +193,7 @@ export class ExplicitContextCacheManager {
   }
 
   private getMinimumStaticPrefixCharacters(): number {
-    const configured = Number.parseInt(
-      process.env.PROXY_CONTEXT_CACHE_MIN_CHARACTERS ?? '',
-      10,
-    );
+    const configured = Number.parseInt(process.env.PROXY_CONTEXT_CACHE_MIN_CHARACTERS ?? '', 10);
     return configured > 0 ? configured : MIN_STATIC_PREFIX_CHARACTERS;
   }
 


### PR DESCRIPTION
`main` does not pass its own formatting gate, so every incoming pull request starts red through no fault of its own. Both #242 and #243 show `Check formatting` failing on five files neither of them touches.

The reason it went unnoticed is the trigger:

```yaml
# .github/workflows/format.yaml
on:
  pull_request:
    branches: [main]
```

`testing.yaml` runs on `push` to main as well, but the formatting workflow runs only on pull requests, so nothing checks main itself and it drifted.

This is `prettier --write` on the five files, nothing else:

```
AGENTS.md
src/modules/proxy-gateway/antigravity/OpenAIResponsesResponseMapper.ts
src/modules/proxy-gateway/antigravity/OpenAIUsageMapper.ts
src/modules/proxy-gateway/server/guards/proxy.guard.ts
src/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.store.ts
```

5 files, +12/-12, all of it line joining and wrapping. No statement changes.

After this, `prettier --check .` is clean across the repository.

If you want the gate to also catch this on main rather than only on pull requests, adding `push: branches: [main]` to `format.yaml` would do it. Left out of this PR so it stays a single mechanical change, happy to send it separately.
