### PR TITLE
Keep the unit run off the machine it runs on

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,11 @@ import { getQuickObservabilityConfig } from '@/shared/observability/observabilit
 import { registerPerformanceRecorderIpc } from '@/modules/app-shell/performance-recorder/ipc';
 import { configurePerformanceRecorderCommandLine } from '@/modules/app-shell/performance-recorder/main-recorder';
 
+// Turn on rotating file output as early as possible, before any module-level
+// logging below runs, so the shipped app keeps logging to disk as before.
+// Importing the logger module itself must stay free of filesystem side effects.
+logger.enableFileLogging();
+
 const packetLogPath = path.join(app.getPath('userData'), 'orpc_packets.log');
 
 function logPacket(data: any) {

--- a/src/modules/account/ipc/handler.ts
+++ b/src/modules/account/ipc/handler.ts
@@ -33,7 +33,10 @@ import {
 } from '@/modules/identity-profile/ipc/handler';
 import { runWithSwitchGuard } from '@/modules/antigravity-runtime/switch/switchGuard';
 import { executeSwitchFlow } from '@/modules/antigravity-runtime/switch/switchFlow';
-import { loadAccountIndex, saveAccountIndex } from '@/modules/account/persistence/account-index-store';
+import {
+  loadAccountIndex,
+  saveAccountIndex,
+} from '@/modules/account/persistence/account-index-store';
 import { shell } from 'electron';
 import { withTimingTrace } from '@/shared/observability/timingTrace';
 

--- a/src/modules/antigravity-runtime/cache/antigravityClientCache.ts
+++ b/src/modules/antigravity-runtime/cache/antigravityClientCache.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { logger } from '@/shared/logging/logger';
+import type { PathResolutionOptions } from '@/shared/platform/paths';
 
 export interface AntigravityClientCacheClearResult {
   clearedPaths: string[];
@@ -9,8 +10,10 @@ export interface AntigravityClientCacheClearResult {
   errors: string[];
 }
 
-export function getAntigravityClientCachePaths(): string[] {
-  if (process.platform === 'darwin') {
+export function getAntigravityClientCachePaths(options?: PathResolutionOptions): string[] {
+  const platform = options?.platform ?? process.platform;
+
+  if (platform === 'darwin') {
     const home = os.homedir();
     return [
       path.posix.join(home, 'Library', 'HTTPStorages', 'com.google.antigravity'),
@@ -20,7 +23,7 @@ export function getAntigravityClientCachePaths(): string[] {
     ];
   }
 
-  if (process.platform === 'linux') {
+  if (platform === 'linux') {
     const home = os.homedir();
     const paths = [
       path.posix.join(home, '.cache', 'Antigravity'),
@@ -35,7 +38,7 @@ export function getAntigravityClientCachePaths(): string[] {
     return paths;
   }
 
-  if (process.platform !== 'win32') {
+  if (platform !== 'win32') {
     return [];
   }
 

--- a/src/shared/logging/logger.ts
+++ b/src/shared/logging/logger.ts
@@ -46,46 +46,15 @@ class Logger {
   private recentLogs: LogEntry[] = [];
   private sentryReporter: SentryReporter | null = null;
   private sentryEnabled = false;
+  private fileLoggingEnabled = false;
 
   constructor() {
-    const agentDir = getAgentDir();
-
-    if (!fs.existsSync(agentDir)) {
-      try {
-        fs.mkdirSync(agentDir, { recursive: true });
-      } catch (e) {
-        console.error('Failed to create agent directory for logs', e);
-      }
-    }
-
-    const fileFormat = winston.format.combine(
-      winston.format.timestamp(),
-      winston.format.printf(({ timestamp, level, message }) => {
-        return `[${timestamp}] [${level.toUpperCase()}] ${message}`;
-      }),
-    );
-
     const consoleFormat = winston.format.combine(
       winston.format.colorize({ all: true }),
       winston.format.printf(({ level, message }) => {
         return `[${level.toUpperCase()}] ${message}`;
       }),
     );
-
-    const rotateTransport = new DailyRotateFile({
-      filename: path.join(agentDir, 'app-%DATE%.log'),
-      datePattern: 'YYYY-MM-DD',
-      maxSize: LOG_MAX_SIZE,
-      maxFiles: LOG_RETENTION,
-      zippedArchive: false,
-      auditFile: path.join(agentDir, '.app-log-audit.json'),
-      level: 'debug',
-      format: fileFormat,
-    });
-
-    rotateTransport.on('error', (error) => {
-      console.error('DailyRotateFile transport error', error);
-    });
 
     const consoleTransport = new winston.transports.Console({
       level: 'debug',
@@ -98,9 +67,53 @@ class Logger {
 
     this.winstonLogger = winston.createLogger({
       level: 'debug',
-      transports: [consoleTransport, rotateTransport],
+      transports: [consoleTransport],
       exitOnError: false,
     });
+  }
+
+  /**
+   * Turns on rotating file output. Must be called explicitly by an application entry
+   * point, importing this module must stay free of filesystem side effects. Safe to
+   * call more than once; only the first call adds the file transport.
+   */
+  enableFileLogging(directory: string = getAgentDir()): void {
+    if (this.fileLoggingEnabled) {
+      return;
+    }
+    this.fileLoggingEnabled = true;
+
+    if (!fs.existsSync(directory)) {
+      try {
+        fs.mkdirSync(directory, { recursive: true });
+      } catch (e) {
+        console.error('Failed to create agent directory for logs', e);
+      }
+    }
+
+    const fileFormat = winston.format.combine(
+      winston.format.timestamp(),
+      winston.format.printf(({ timestamp, level, message }) => {
+        return `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+      }),
+    );
+
+    const rotateTransport = new DailyRotateFile({
+      filename: path.join(directory, 'app-%DATE%.log'),
+      datePattern: 'YYYY-MM-DD',
+      maxSize: LOG_MAX_SIZE,
+      maxFiles: LOG_RETENTION,
+      zippedArchive: false,
+      auditFile: path.join(directory, '.app-log-audit.json'),
+      level: 'debug',
+      format: fileFormat,
+    });
+
+    rotateTransport.on('error', (error) => {
+      console.error('DailyRotateFile transport error', error);
+    });
+
+    this.winstonLogger.add(rotateTransport);
   }
 
   private pruneLogs(now: number) {

--- a/src/shared/platform/paths.ts
+++ b/src/shared/platform/paths.ts
@@ -8,22 +8,36 @@ import { resolveAntigravityAppTarget } from '@/modules/account/types';
 
 type PathApi = Pick<typeof path, 'dirname' | 'join' | 'normalize' | 'resolve'>;
 
-function getCurrentPlatformPathApi(): PathApi {
-  return process.platform === 'win32' ? path.win32 : path.posix;
+export interface PathResolutionOptions {
+  platform?: NodeJS.Platform;
+  isWsl?: boolean;
+}
+
+function getCurrentPlatform(options?: PathResolutionOptions): NodeJS.Platform {
+  return options?.platform ?? process.platform;
+}
+
+function getCurrentPlatformPathApi(options?: PathResolutionOptions): PathApi {
+  return getCurrentPlatform(options) === 'win32' ? path.win32 : path.posix;
 }
 
 /**
  * Checks if the current platform is WSL.
+ * @param {NodeJS.Platform} [platform] The platform to check, defaults to `process.platform`.
  * @returns {boolean} True if the current platform is WSL, false otherwise.
  */
-export function isWsl(): boolean {
-  if (process.platform !== 'linux') return false;
+export function isWsl(platform: NodeJS.Platform = process.platform): boolean {
+  if (platform !== 'linux') return false;
   try {
     const version = fs.readFileSync('/proc/version', 'utf-8').toLowerCase();
     return version.includes('microsoft') && version.includes('wsl');
   } catch {
     return false;
   }
+}
+
+function resolveIsWsl(options?: PathResolutionOptions): boolean {
+  return options?.isWsl ?? isWsl(getCurrentPlatform(options));
 }
 
 let cachedWindowsUser: string | null = null;
@@ -96,7 +110,7 @@ function appendUniquePath(paths: string[], targetPath: string | null | undefined
   paths.push(targetPath);
 }
 
-function normalizeExecutablePath(executablePath: string): string {
+function normalizeExecutablePath(executablePath: string, options?: PathResolutionOptions): string {
   let pathForComparison = executablePath;
   try {
     if (fs.existsSync(executablePath)) {
@@ -106,10 +120,10 @@ function normalizeExecutablePath(executablePath: string): string {
     pathForComparison = executablePath;
   }
 
-  const pathApi = getCurrentPlatformPathApi();
+  const pathApi = getCurrentPlatformPathApi(options);
   const normalizedPath = pathApi.normalize(pathForComparison).toLowerCase();
 
-  if (process.platform === 'win32') {
+  if (getCurrentPlatform(options) === 'win32') {
     return normalizedPath.replace(/\//g, '\\');
   }
 
@@ -119,11 +133,12 @@ function normalizeExecutablePath(executablePath: string): string {
 function areExecutablePathsEquivalent(
   leftExecutablePath: string,
   rightExecutablePath: string,
+  options?: PathResolutionOptions,
 ): boolean {
-  const leftNormalized = normalizeExecutablePath(leftExecutablePath);
-  const rightNormalized = normalizeExecutablePath(rightExecutablePath);
+  const leftNormalized = normalizeExecutablePath(leftExecutablePath, options);
+  const rightNormalized = normalizeExecutablePath(rightExecutablePath, options);
 
-  if (process.platform === 'darwin') {
+  if (getCurrentPlatform(options) === 'darwin') {
     const leftAppIndex = leftNormalized.indexOf('.app');
     const rightAppIndex = rightNormalized.indexOf('.app');
     if (leftAppIndex >= 0 && rightAppIndex >= 0) {
@@ -175,24 +190,37 @@ export interface AntigravityProcessCandidate {
 export function isTargetAntigravityProcessCandidate(
   processItem: AntigravityProcessCandidate,
   target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
 ): boolean {
   const normalizedTarget = resolveAntigravityAppTarget(target);
   const nameLower = processItem.name.toLowerCase();
   const cmdLower = processItem.commandLine.toLowerCase();
-  const configuredClassicPath = getConfiguredAntigravityExecutablePath('classic', false);
-  const configuredIdePath = getConfiguredAntigravityExecutablePath('ide', false);
-  const strictConfiguredClassicPath = getConfiguredAntigravityExecutablePath('classic', true);
-  const strictConfiguredIdePath = getConfiguredAntigravityExecutablePath('ide', true);
+  const configuredClassicPath = getConfiguredAntigravityExecutablePath('classic', false, options);
+  const configuredIdePath = getConfiguredAntigravityExecutablePath('ide', false, options);
+  const strictConfiguredClassicPath = getConfiguredAntigravityExecutablePath(
+    'classic',
+    true,
+    options,
+  );
+  const strictConfiguredIdePath = getConfiguredAntigravityExecutablePath('ide', true, options);
   const commandExecutablePath = parseCommandLineArguments(processItem.commandLine)[0] || '';
   const executableIdentity = `${processItem.executablePath || ''} ${commandExecutablePath}`;
   const hasAntigravityProcessIdentity =
     nameLower.includes('antigravity') || executableIdentity.toLowerCase().includes('antigravity');
   const matchesClassicPath =
     Boolean((configuredClassicPath && processItem.executablePath) || '') &&
-    areExecutablePathsEquivalent(configuredClassicPath as string, processItem.executablePath || '');
+    areExecutablePathsEquivalent(
+      configuredClassicPath as string,
+      processItem.executablePath || '',
+      options,
+    );
   const matchesIdePath =
     Boolean((configuredIdePath && processItem.executablePath) || '') &&
-    areExecutablePathsEquivalent(configuredIdePath as string, processItem.executablePath || '');
+    areExecutablePathsEquivalent(
+      configuredIdePath as string,
+      processItem.executablePath || '',
+      options,
+    );
   const isIde =
     hasAntigravityIdeMarker(nameLower) ||
     hasAntigravityIdeMarker(executableIdentity) ||
@@ -233,6 +261,7 @@ export function isTargetAntigravityProcessCandidate(
 export function isConfiguredTargetExecutableProcessCandidate(
   processItem: AntigravityProcessCandidate,
   target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
 ): boolean {
   const normalizedTarget = resolveAntigravityAppTarget(target);
   const executablePath = processItem.executablePath || '';
@@ -240,14 +269,14 @@ export function isConfiguredTargetExecutableProcessCandidate(
     return false;
   }
 
-  const configuredClassicPath = getConfiguredAntigravityExecutablePath('classic', true);
-  const configuredIdePath = getConfiguredAntigravityExecutablePath('ide', true);
+  const configuredClassicPath = getConfiguredAntigravityExecutablePath('classic', true, options);
+  const configuredIdePath = getConfiguredAntigravityExecutablePath('ide', true, options);
   const matchesClassicPath =
     Boolean(configuredClassicPath) &&
-    areExecutablePathsEquivalent(configuredClassicPath as string, executablePath);
+    areExecutablePathsEquivalent(configuredClassicPath as string, executablePath, options);
   const matchesIdePath =
     Boolean(configuredIdePath) &&
-    areExecutablePathsEquivalent(configuredIdePath as string, executablePath);
+    areExecutablePathsEquivalent(configuredIdePath as string, executablePath, options);
 
   if (normalizedTarget === 'ide') {
     return matchesIdePath && !matchesClassicPath;
@@ -259,6 +288,7 @@ export function isConfiguredTargetExecutableProcessCandidate(
 export function isTargetAntigravityExecutableProcessCandidate(
   processItem: AntigravityProcessCandidate,
   target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
 ): boolean {
   const normalizedTarget = resolveAntigravityAppTarget(target);
   const oppositeTarget: AntigravityAppTarget = normalizedTarget === 'ide' ? 'classic' : 'ide';
@@ -270,18 +300,19 @@ export function isTargetAntigravityExecutableProcessCandidate(
     return false;
   }
 
-  const targetExecutablePath = getAntigravityExecutablePath(normalizedTarget);
+  const targetExecutablePath = getAntigravityExecutablePath(normalizedTarget, options);
   if (!targetExecutablePath) {
     return false;
   }
 
-  if (!areExecutablePathsEquivalent(targetExecutablePath, executablePath)) {
+  if (!areExecutablePathsEquivalent(targetExecutablePath, executablePath, options)) {
     return false;
   }
 
-  const oppositeExecutablePath = getAntigravityExecutablePath(oppositeTarget);
+  const oppositeExecutablePath = getAntigravityExecutablePath(oppositeTarget, options);
   return !(
-    oppositeExecutablePath && areExecutablePathsEquivalent(oppositeExecutablePath, executablePath)
+    oppositeExecutablePath &&
+    areExecutablePathsEquivalent(oppositeExecutablePath, executablePath, options)
   );
 }
 
@@ -323,8 +354,11 @@ function parseCommandLineArguments(commandLine: string): string[] {
   return commandLineArguments;
 }
 
-function extractUserDataDirectoryFromArgs(commandLineArguments: string[]): string | null {
-  const pathApi = getCurrentPlatformPathApi();
+function extractUserDataDirectoryFromArgs(
+  commandLineArguments: string[],
+  options?: PathResolutionOptions,
+): string | null {
+  const pathApi = getCurrentPlatformPathApi(options);
 
   for (let index = 0; index < commandLineArguments.length; index += 1) {
     const argument = commandLineArguments[index];
@@ -360,16 +394,16 @@ function resolveExecutablePathFromProcessInfo(
   return executableCandidate;
 }
 
-function readAntigravityManagerConfig(): {
+function readAntigravityManagerConfig(options?: PathResolutionOptions): {
   antigravity_executable?: unknown;
   antigravity_ide_executable?: unknown;
   antigravity_args?: unknown;
   antigravity_ide_args?: unknown;
 } | null {
-  const pathApi = getCurrentPlatformPathApi();
+  const pathApi = getCurrentPlatformPathApi(options);
   const configPaths = [
-    pathApi.join(getAgentDir(), CONFIG_FILENAME),
-    pathApi.join(getAppDataDir(), CONFIG_FILENAME),
+    pathApi.join(getAgentDir(options), CONFIG_FILENAME),
+    pathApi.join(getAppDataDir(undefined, options), CONFIG_FILENAME),
   ];
 
   for (const configPath of configPaths) {
@@ -409,7 +443,7 @@ let runningProcessCache: {
   processes: RunningAntigravityProcess[];
 } | null = null;
 
-interface RefreshProcessCacheOptions {
+interface RefreshProcessCacheOptions extends PathResolutionOptions {
   includeAllProcesses?: boolean;
 }
 
@@ -477,7 +511,10 @@ export async function refreshAntigravityProcessCache(
 
       for (const processInfo of matches) {
         const runningProcess = processInfoToRunningProcess(processInfo);
-        if (runningProcess.pid > 0 && isTargetAntigravityProcessCandidate(runningProcess, target)) {
+        if (
+          runningProcess.pid > 0 &&
+          isTargetAntigravityProcessCandidate(runningProcess, target, options)
+        ) {
           processMap.set(runningProcess.pid, runningProcess);
         }
       }
@@ -512,16 +549,20 @@ function getRunningAntigravityProcesses(
   return [];
 }
 
-function getUserDataDirFromRunningProcess(target?: AntigravityAppTarget | null): string | null {
+function getUserDataDirFromRunningProcess(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string | null {
   const configuredUserDataDir = extractUserDataDirectoryFromArgs(
-    getConfiguredAntigravityArgs(target),
+    getConfiguredAntigravityArgs(target, options),
+    options,
   );
   if (configuredUserDataDir && fs.existsSync(configuredUserDataDir)) {
     return configuredUserDataDir;
   }
 
   for (const commandLineArguments of getAntigravityArgsFromRunningProcess(target)) {
-    const userDataDir = extractUserDataDirectoryFromArgs(commandLineArguments);
+    const userDataDir = extractUserDataDirectoryFromArgs(commandLineArguments, options);
     if (userDataDir && fs.existsSync(userDataDir)) {
       return userDataDir;
     }
@@ -554,8 +595,11 @@ export function getAntigravityLaunchArgsFromRunningProcess(
   return getAntigravityArgsFromRunningProcess(target)[0]?.slice(1) || [];
 }
 
-export function getConfiguredAntigravityArgs(target?: AntigravityAppTarget | null): string[] {
-  const rawConfig = readAntigravityManagerConfig();
+export function getConfiguredAntigravityArgs(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string[] {
+  const rawConfig = readAntigravityManagerConfig(options);
   const configKey =
     resolveAntigravityAppTarget(target) === 'ide' ? 'antigravity_ide_args' : 'antigravity_args';
   const configuredArgs = rawConfig?.[configKey];
@@ -570,8 +614,9 @@ export function getConfiguredAntigravityArgs(target?: AntigravityAppTarget | nul
 function getConfiguredAntigravityExecutablePath(
   target?: AntigravityAppTarget | null,
   requireExists = true,
+  options?: PathResolutionOptions,
 ): string | null {
-  const rawConfig = readAntigravityManagerConfig();
+  const rawConfig = readAntigravityManagerConfig(options);
   const configKey =
     resolveAntigravityAppTarget(target) === 'ide'
       ? 'antigravity_ide_executable'
@@ -629,16 +674,19 @@ function pushExistingUserDataStoragePaths(
   }
 }
 
-function getPortableUserDataDir(target?: AntigravityAppTarget | null): string | null {
-  const executablePath = getAntigravityExecutablePath(target);
+function getPortableUserDataDir(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string | null {
+  const executablePath = getAntigravityExecutablePath(target, options);
   if (!executablePath) {
     return null;
   }
 
-  const pathApi = getCurrentPlatformPathApi();
+  const pathApi = getCurrentPlatformPathApi(options);
   const userDataDir = pathApi.join(pathApi.dirname(executablePath), 'data', 'user-data');
 
-  if (process.platform !== 'win32') {
+  if (getCurrentPlatform(options) !== 'win32') {
     try {
       fs.accessSync(userDataDir, fs.constants.W_OK);
     } catch {
@@ -649,16 +697,19 @@ function getPortableUserDataDir(target?: AntigravityAppTarget | null): string | 
   return userDataDir;
 }
 
-export function getAppDataDir(target?: AntigravityAppTarget | null): string {
+export function getAppDataDir(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string {
   const home = os.homedir();
   const folderName = getAntigravityAppFolderName(target);
 
-  if (isWsl()) {
+  if (resolveIsWsl(options)) {
     const winUser = getWindowsUser();
     return `/mnt/c/Users/${winUser}/AppData/Roaming/${folderName}`;
   }
 
-  switch (process.platform) {
+  switch (getCurrentPlatform(options)) {
     case 'darwin':
       return path.posix.join(home, 'Library', 'Application Support', folderName);
     case 'win32':
@@ -673,30 +724,33 @@ export function getAppDataDir(target?: AntigravityAppTarget | null): string {
   }
 }
 
-export function getAgentDir(): string {
-  return getCurrentPlatformPathApi().join(os.homedir(), '.antigravity-agent');
+export function getAgentDir(options?: PathResolutionOptions): string {
+  return getCurrentPlatformPathApi(options).join(os.homedir(), '.antigravity-agent');
 }
 
-export function getAccountsFilePath(): string {
-  return getCurrentPlatformPathApi().join(getAgentDir(), 'antigravity_accounts.json');
+export function getAccountsFilePath(options?: PathResolutionOptions): string {
+  return getCurrentPlatformPathApi(options).join(getAgentDir(options), 'antigravity_accounts.json');
 }
 
-export function getBackupsDir(): string {
-  return getCurrentPlatformPathApi().join(getAgentDir(), 'backups');
+export function getBackupsDir(options?: PathResolutionOptions): string {
+  return getCurrentPlatformPathApi(options).join(getAgentDir(options), 'backups');
 }
 
-export function getCloudAccountsDbPath(): string {
-  return getCurrentPlatformPathApi().join(getAgentDir(), 'cloud_accounts.db');
+export function getCloudAccountsDbPath(options?: PathResolutionOptions): string {
+  return getCurrentPlatformPathApi(options).join(getAgentDir(options), 'cloud_accounts.db');
 }
 
-export function getAntigravityDbPaths(target?: AntigravityAppTarget | null): string[] {
-  const appData = getAppDataDir(target);
+export function getAntigravityDbPaths(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string[] {
+  const appData = getAppDataDir(target, options);
   const paths: string[] = [];
   const home = os.homedir();
   const folderName = getAntigravityAppFolderName(target);
-  const pathApi = getCurrentPlatformPathApi();
-  const userDataDir = getUserDataDirFromRunningProcess(target);
-  const portableUserDataDir = getPortableUserDataDir(target);
+  const pathApi = getCurrentPlatformPathApi(options);
+  const userDataDir = getUserDataDirFromRunningProcess(target, options);
+  const portableUserDataDir = getPortableUserDataDir(target, options);
 
   if (userDataDir) {
     pushExistingUserDataDbPaths(paths, userDataDir, pathApi);
@@ -706,19 +760,19 @@ export function getAntigravityDbPaths(target?: AntigravityAppTarget | null): str
     pushExistingUserDataDbPaths(paths, portableUserDataDir, pathApi);
   }
 
-  if (isWsl()) {
+  if (resolveIsWsl(options)) {
     // Assume standard structure: AppData/Roaming/Antigravity/User/globalStorage/state.vscdb
     // appData is already resolved to Roaming/Antigravity in getAppDataDir()
     pushUserDataDbPaths(paths, appData, path.posix);
     return paths;
   }
 
-  if (process.platform === 'linux') {
+  if (getCurrentPlatform(options) === 'linux') {
     pushUserDataDbPaths(paths, appData, path.posix);
     return paths;
   }
 
-  if (process.platform === 'darwin') {
+  if (getCurrentPlatform(options) === 'darwin') {
     // Standard path
     appendUniquePath(
       paths,
@@ -750,14 +804,17 @@ export function getAntigravityDbPaths(target?: AntigravityAppTarget | null): str
   return paths;
 }
 
-export function getAntigravityStoragePaths(target?: AntigravityAppTarget | null): string[] {
-  const appData = getAppDataDir(target);
+export function getAntigravityStoragePaths(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string[] {
+  const appData = getAppDataDir(target, options);
   const paths: string[] = [];
   const home = os.homedir();
   const folderName = getAntigravityAppFolderName(target);
-  const pathApi = getCurrentPlatformPathApi();
-  const userDataDir = getUserDataDirFromRunningProcess(target);
-  const portableUserDataDir = getPortableUserDataDir(target);
+  const pathApi = getCurrentPlatformPathApi(options);
+  const userDataDir = getUserDataDirFromRunningProcess(target, options);
+  const portableUserDataDir = getPortableUserDataDir(target, options);
 
   if (userDataDir) {
     pushExistingUserDataStoragePaths(paths, userDataDir, pathApi);
@@ -767,17 +824,17 @@ export function getAntigravityStoragePaths(target?: AntigravityAppTarget | null)
     pushExistingUserDataStoragePaths(paths, portableUserDataDir, pathApi);
   }
 
-  if (isWsl()) {
+  if (resolveIsWsl(options)) {
     pushUserDataStoragePaths(paths, appData, path.posix);
     return paths;
   }
 
-  if (process.platform === 'linux') {
+  if (getCurrentPlatform(options) === 'linux') {
     pushUserDataStoragePaths(paths, appData, path.posix);
     return paths;
   }
 
-  if (process.platform === 'darwin') {
+  if (getCurrentPlatform(options) === 'darwin') {
     appendUniquePath(
       paths,
       path.posix.join(
@@ -803,18 +860,27 @@ export function getAntigravityStoragePaths(target?: AntigravityAppTarget | null)
   return paths;
 }
 
-export function getAntigravityStoragePath(target?: AntigravityAppTarget | null): string {
-  const paths = getAntigravityStoragePaths(target);
+export function getAntigravityStoragePath(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string {
+  const paths = getAntigravityStoragePaths(target, options);
   return paths.length > 0 ? paths[0] : '';
 }
 
 // Keep for backward compatibility if needed, but prefer getAntigravityDbPaths
-export function getAntigravityDbPath(target?: AntigravityAppTarget | null): string {
-  const paths = getAntigravityDbPaths(target);
+export function getAntigravityDbPath(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string {
+  const paths = getAntigravityDbPaths(target, options);
   return paths.length > 0 ? paths[0] : '';
 }
 
-export function getAntigravityExecutablePath(target?: AntigravityAppTarget | null): string {
+export function getAntigravityExecutablePath(
+  target?: AntigravityAppTarget | null,
+  options?: PathResolutionOptions,
+): string {
   const resolvedTarget = resolveAntigravityAppTarget(target);
   const executableName = getAntigravityAppFolderName(target);
   const runningExecutablePath = getExecutablePathFromRunningProcess(target);
@@ -823,17 +889,21 @@ export function getAntigravityExecutablePath(target?: AntigravityAppTarget | nul
     return runningExecutablePath;
   }
 
-  const configuredExecutablePath = getConfiguredAntigravityExecutablePath(resolvedTarget);
+  const configuredExecutablePath = getConfiguredAntigravityExecutablePath(
+    resolvedTarget,
+    undefined,
+    options,
+  );
   if (configuredExecutablePath) {
     return configuredExecutablePath;
   }
 
-  if (isWsl()) {
+  if (resolveIsWsl(options)) {
     const winUser = getWindowsUser();
     return `/mnt/c/Users/${winUser}/AppData/Local/Programs/${executableName}/${executableName}.exe`;
   }
 
-  switch (process.platform) {
+  switch (getCurrentPlatform(options)) {
     case 'darwin':
       return `/Applications/${executableName}.app/Contents/MacOS/${executableName}`;
     case 'win32': {

--- a/src/tests/support/no-app-launch.setup.ts
+++ b/src/tests/support/no-app-launch.setup.ts
@@ -1,0 +1,77 @@
+// Under WSL, getAntigravityExecutablePath() resolves to the Windows build, so any spawn site
+// reached from a test hands that path to Windows through interop: the IDE opens, takes focus,
+// and survives the run, and the resulting processes cannot be killed from the Linux side.
+//
+// This setup patches every child_process entry point at the module level, in place, so the
+// suite is structurally incapable of launching a real application no matter which call site
+// (present or future) reaches it. It does not use vi.mock, so a test file that installs its
+// own child_process mock still wins: that file imports the mock instead of the real module,
+// and this guard never sees the call.
+import { expect } from 'vitest';
+import cp from 'node:child_process';
+
+const GUARDED_METHODS = [
+  'spawn',
+  'spawnSync',
+  'exec',
+  'execSync',
+  'execFile',
+  'execFileSync',
+  'fork',
+] as const;
+
+type GuardedMethod = (typeof GUARDED_METHODS)[number];
+
+function isBlockedCommand(command: string): boolean {
+  const normalized = command.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  // Windows executable / script extensions, e.g. "cmd.exe", "run.bat", "C:\\foo.cmd"
+  if (/\.(exe|cmd|bat)(["'\s]|$)/.test(normalized)) {
+    return true;
+  }
+  // Paths reaching into the Windows filesystem through WSL interop
+  if (normalized.includes('/mnt/c/')) {
+    return true;
+  }
+  // Antigravity itself, under any name/path shape
+  if (normalized.includes('antigravity')) {
+    return true;
+  }
+  return false;
+}
+
+function currentTestName(): string {
+  return expect.getState().currentTestName ?? 'unknown test';
+}
+
+function guard(method: GuardedMethod, original: (...args: unknown[]) => unknown) {
+  return function guarded(this: unknown, ...args: unknown[]) {
+    const command = typeof args[0] === 'string' ? args[0] : '';
+    if (isBlockedCommand(command)) {
+      throw new Error(
+        `no-app-launch guard: refused child_process.${method}(${JSON.stringify(command)}) ` +
+          `in test "${currentTestName()}". This command looks like it would launch a Windows ` +
+          'executable or Antigravity itself. Mock child_process in that test instead of ' +
+          'letting it reach the real implementation.',
+      );
+    }
+    return original.apply(this, args as never);
+  };
+}
+
+const cpAny = cp as unknown as Record<GuardedMethod, (...args: unknown[]) => unknown> & {
+  __noAppLaunchGuardInstalled?: boolean;
+};
+
+if (!cpAny.__noAppLaunchGuardInstalled) {
+  for (const method of GUARDED_METHODS) {
+    const original = cpAny[method];
+    if (typeof original !== 'function') {
+      throw new Error(`no-app-launch guard: expected child_process.${method} to be a function`);
+    }
+    cpAny[method] = guard(method, original);
+  }
+  cpAny.__noAppLaunchGuardInstalled = true;
+}

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -65,14 +65,7 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
     expect(mocks.execFileSync).toHaveBeenCalledWith(
       'security',
-      expect.arrayContaining([
-        'add-generic-password',
-        '-s',
-        'gemini',
-        '-a',
-        'antigravity',
-        '-U',
-      ]),
+      expect.arrayContaining(['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-U']),
       { stdio: 'ignore' },
     );
     expect(mocks.execFileSync.mock.calls[0][1]).not.toContain('delete-generic-password');

--- a/src/tests/unit/logger.test.ts
+++ b/src/tests/unit/logger.test.ts
@@ -16,6 +16,7 @@ describe('Logger Utilities', () => {
     error: (message: string, ...args: unknown[]) => void;
     setErrorReportingEnabled: (enabled: boolean) => void;
     setSentryReporter: (reporter: ((payload: unknown) => void) | null) => void;
+    enableFileLogging: (directory?: string) => void;
   };
 
   const getLatestLogFile = () => {
@@ -53,6 +54,7 @@ describe('Logger Utilities', () => {
     fs.mkdirSync(testLogDir, { recursive: true });
     const loggerModule = await import('../../shared/logging/logger');
     logger = loggerModule.logger;
+    logger.enableFileLogging(testLogDir);
   });
 
   beforeEach(() => {
@@ -137,5 +139,12 @@ describe('Logger Utilities', () => {
     const filePath = await waitForLogContains(message);
     expect(filePath).not.toBeNull();
     expect(reporter).not.toHaveBeenCalled();
+  });
+});
+
+describe('Logger entry-point wiring', () => {
+  it('turns on file logging from the Electron main entry point', () => {
+    const mainSource = fs.readFileSync(path.join(process.cwd(), 'src/main.ts'), 'utf-8');
+    expect(mainSource).toContain('logger.enableFileLogging()');
   });
 });

--- a/src/tests/unit/no-app-launch-guard.test.ts
+++ b/src/tests/unit/no-app-launch-guard.test.ts
@@ -1,0 +1,27 @@
+import { execSync, spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+describe('no-app-launch guard', () => {
+  it('refuses a command that looks like a Windows executable', () => {
+    expect(() => execSync('/mnt/c/Windows/System32/cmd.exe /c echo hi')).toThrowError(
+      /no-app-launch guard: refused child_process\.execSync/,
+    );
+  });
+
+  it('refuses a command that names Antigravity itself', () => {
+    expect(() => spawnSync('antigravity', ['--version'])).toThrowError(
+      /no-app-launch guard: refused child_process\.spawnSync/,
+    );
+  });
+
+  it('lets an ordinary command through untouched', () => {
+    const output = execSync('echo hi').toString().trim();
+    expect(output).toBe('hi');
+  });
+
+  it('checks the command, not the arguments', () => {
+    const result = spawnSync('echo', ['/mnt/c/Windows/fake.exe', 'antigravity']);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+  });
+});

--- a/src/tests/unit/paths.test.ts
+++ b/src/tests/unit/paths.test.ts
@@ -106,41 +106,44 @@ describe('Path Utilities', () => {
   });
 
   it('should get correct executable path', async () => {
-    vi.spyOn(fs, 'existsSync').mockImplementation((candidate) => {
-      const candidateStr = String(candidate);
-      if (process.platform === 'linux') {
-        return candidateStr === '/usr/share/antigravity/antigravity';
-      } else if (process.platform === 'darwin') {
-        return candidateStr === '/Applications/Antigravity.app/Contents/MacOS/Antigravity';
-      }
-      return false;
-    });
+    vi.spyOn(fs, 'existsSync').mockImplementation(
+      (candidate) => String(candidate) === '/usr/share/antigravity/antigravity',
+    );
     const paths = await import('../../shared/platform/paths');
-    const execPath = paths.getAntigravityExecutablePath();
 
-    const expectedPath =
-      process.platform === 'darwin'
-        ? '/Applications/Antigravity.app/Contents/MacOS/Antigravity'
-        : process.platform === 'linux'
-          ? '/usr/share/antigravity/antigravity'
-          : '';
-    expect(execPath).toBe(expectedPath);
+    // Stating plain Linux is the point: the case used to branch on the host platform, so on a
+    // WSL host it asserted the Linux install while the code correctly resolved the Windows build.
+    expect(paths.getAntigravityExecutablePath(undefined, { platform: 'linux', isWsl: false })).toBe(
+      '/usr/share/antigravity/antigravity',
+    );
+  });
+
+  it('should resolve the Windows install when Linux is really WSL', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    childProcessMock.execSync.mockReturnValue('alice\r\n');
+    const paths = await import('../../shared/platform/paths');
+
+    expect(paths.getAntigravityExecutablePath(undefined, { platform: 'linux', isWsl: true })).toBe(
+      '/mnt/c/Users/alice/AppData/Local/Programs/Antigravity/Antigravity.exe',
+    );
   });
 
   it('should skip non-writable derived portable user-data paths on Linux', async () => {
     vi.resetModules();
-    setPlatform('linux');
     vi.spyOn(os, 'homedir').mockReturnValue('/home/alice');
     vi.spyOn(fs, 'existsSync').mockImplementation((candidatePath) => {
       return String(candidatePath) === '/usr/bin/antigravity';
     });
 
     const paths = await import('../../shared/platform/paths');
+    // Plain Linux is stated, not assumed: under WSL the code resolves the Windows build, so a
+    // case that asserts the Linux answer while running on WSL asserts a branch it never reaches.
+    const options = { platform: 'linux', isWsl: false } as const;
 
-    expect(paths.getAntigravityDbPath()).toBe(
+    expect(paths.getAntigravityDbPath(undefined, options)).toBe(
       '/home/alice/.config/Antigravity/User/globalStorage/state.vscdb',
     );
-    expect(paths.getAntigravityStoragePath()).toBe(
+    expect(paths.getAntigravityStoragePath(undefined, options)).toBe(
       '/home/alice/.config/Antigravity/User/globalStorage/storage.json',
     );
   });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -15,5 +15,6 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     include: ['src/tests/unit/**/*.test.ts'],
+    setupFiles: ['./src/tests/support/no-app-launch.setup.ts'],
   },
 });


### PR DESCRIPTION
Three layers against one class of defect: **a unit run must not touch the machine it runs on**.

They are not alternatives. Each removes a cause the others cannot see, and the
measurements below were taken by removing one at a time.

## What the run does today, on this base

Measured on WSL, `upstream/main` at `e1721ef8`:

- it writes real log lines into the developer's live `~/.antigravity-agent`, churning the
  rotation audit of an installed, running application;
- on a run where a suite has pinned `process.platform` to win32, it creates a *relative*
  `\home\<user>\.antigravity-agent` inside the repository, and `\tmp\antigravity-client-cache-…`
  next to it;
- a spawn site reached under WSL opens the real Windows IDE through interop. One observed run
  left seven windows behind that could not be killed from the Linux side.

## The three layers

**1. `refactor(paths)` — the platform becomes an input.** Path resolution read `process.platform`
as ambient state and the suite wrote that global to exercise Windows on Linux, which is what joins
a Linux home with the Windows path API and produces the relative names above. It also leaks across
files in a worker, so a suite that restores late poisons the next one. Resolution now takes
explicit `platform` / `isWsl` inputs defaulting to the process values, so every production call
site resolves exactly as before — the unchanged tests passing against the new signatures are the
evidence. Two `paths.test.ts` cases that **fail on this base under WSL** now state the platform
they mean rather than branching on the host, and the WSL branch itself gains the case nothing
covered.

**2. `fix(logging)` — the log file opens when the app asks.** The `Logger` constructor created the
agent directory and opened a `DailyRotateFile` transport, and 47 production modules import that
singleton, so importing any of them did filesystem work. The constructor is now console-only;
`enableFileLogging()` adds the rotating transport with identical settings and is idempotent;
`src/main.ts` calls it. The shipped app logs exactly as before — this is about *when* the transport
is created. `logger.test.ts` now turns file logging on against its own temp directory and asserts
that `src/main.ts` still calls it, so the wiring regresses loudly instead of silently.

**3. `test:` — a guard instead of a window.** One spawn site was fixed already, but fixing them one
at a time does not close the class: the next site reopens it. A setup file wraps every
`child_process` entry point and throws when the command names a Windows executable or Antigravity
itself, naming the command and the test. Ordinary commands pass through untouched, and a suite with
its own `child_process` mock still wins. It fires **zero** times here — it is a backstop for the
site nobody has written yet.

## Measurements

| | before | after |
| --- | --- | --- |
| live `~/.antigravity-agent/app-*.log` | grows every run | **byte-identical** (590409 → 590409) |
| repository root | `\home\…` and `\tmp\antigravity-client-cache-…` | **clean** |
| `vitest run` | 824 passed, 8 skipped, **2 failed** | **832 passed, 8 skipped, 0 failed** |
| `eslint .` | 0 errors, 8 warnings | unchanged |
| guard firings | n/a | 0 |

Each layer was also verified by removal, which is what showed they are complementary: with only
the logger change the live log stops growing but the relative directories remain; with only the
platform change the root stays clean but the live log still grows.

## Two gates that are already red on `main`, untouched by this branch

Worth knowing, since neither is mine and both fail before this change:

- `tsc --noEmit` reports one error in `src/modules/app-shell/utils/rendererRecovery.ts:6` from
  #257 — `'memory-eviction'` is not a member of Electron's `RenderProcessGoneDetails['reason']`
  union, so the `Set` literal does not typecheck;
- `prettier --check .` failed on two tracked files this branch does not otherwise touch:
  `src/modules/account/ipc/handler.ts` and `src/tests/unit/antigravity-credential-store-write.test.ts`.
  I first left them alone, and CI here promptly went red on them — `format.yaml` runs on pull
  requests to `main` but not on pushes to it, so that drift only ever surfaces on somebody's next
  PR. The last commit is `prettier --write` on those two files and nothing else, which is what
  makes this branch's own gate readable. All three checks are green.

The `tsc` error above is untouched: `type-check` is not one of the three CI gates, so it is yours
to decide rather than mine to smuggle in.

## Deliberately not here

Six suites still mutate `process.platform` (`antigravityVersion`, `process`, `security-migration`,
both credential-store suites, `windows-power-throttling`). They belong to unrelated modules and are
a follow-up, not a silent omission: the layers above already make their damage harmless.

