### PR TITLE
Keep tool enums inside the string list Gemini accepts

### DIFF
--- a/src/modules/account/ipc/handler.ts
+++ b/src/modules/account/ipc/handler.ts
@@ -33,7 +33,10 @@ import {
 } from '@/modules/identity-profile/ipc/handler';
 import { runWithSwitchGuard } from '@/modules/antigravity-runtime/switch/switchGuard';
 import { executeSwitchFlow } from '@/modules/antigravity-runtime/switch/switchFlow';
-import { loadAccountIndex, saveAccountIndex } from '@/modules/account/persistence/account-index-store';
+import {
+  loadAccountIndex,
+  saveAccountIndex,
+} from '@/modules/account/persistence/account-index-store';
 import { shell } from 'electron';
 import { withTimingTrace } from '@/shared/observability/timingTrace';
 

--- a/src/modules/proxy-gateway/antigravity/JsonSchemaUtils.ts
+++ b/src/modules/proxy-gateway/antigravity/JsonSchemaUtils.ts
@@ -148,6 +148,31 @@ function cleanJsonSchemaRecursive(value: any) {
     // 2. Collect and process validation fields (Migration logic: Downgrade constraints to Hints in description)
     const constraints: string[] = [];
 
+    const enumValues = map.enum;
+    if (enumValues !== undefined) {
+      if (!isArray(enumValues)) {
+        delete map.enum;
+      } else {
+        const primitiveEnumValues = enumValues.filter(
+          (enumValue: unknown) =>
+            isString(enumValue) || isNumber(enumValue) || isBoolean(enumValue),
+        );
+
+        if (primitiveEnumValues.length === 0) {
+          delete map.enum;
+        } else if (primitiveEnumValues.every(isString)) {
+          if (primitiveEnumValues.length !== enumValues.length) {
+            map.enum = primitiveEnumValues;
+          }
+        } else if (isString(map.type) && map.type.toLowerCase() === 'string') {
+          map.enum = primitiveEnumValues.map(String);
+        } else {
+          constraints.push(`enum: ${primitiveEnumValues.join(', ')}`);
+          delete map.enum;
+        }
+      }
+    }
+
     // Validation fields blacklist for migration
     const validationFields = [
       ['pattern', 'pattern'],

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -65,14 +65,7 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
     expect(mocks.execFileSync).toHaveBeenCalledWith(
       'security',
-      expect.arrayContaining([
-        'add-generic-password',
-        '-s',
-        'gemini',
-        '-a',
-        'antigravity',
-        '-U',
-      ]),
+      expect.arrayContaining(['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-U']),
       { stdio: 'ignore' },
     );
     expect(mocks.execFileSync.mock.calls[0][1]).not.toContain('delete-generic-password');

--- a/src/tests/unit/json-schema-utils.test.ts
+++ b/src/tests/unit/json-schema-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { cleanJsonSchema } from '@/modules/proxy-gateway/antigravity/JsonSchemaUtils';
+import {
+  cleanJsonSchema,
+  normalizeObjectJsonSchema,
+} from '@/modules/proxy-gateway/antigravity/JsonSchemaUtils';
 
 describe('cleanJsonSchema', () => {
   it('drops nested boolean sub-schemas and their required entries', () => {
@@ -46,5 +49,164 @@ describe('cleanJsonSchema', () => {
         .excluded,
     ).toBeUndefined();
     expect(properties.invalidItems.items).toBeUndefined();
+  });
+
+  it('preserves string enums without rewriting them', () => {
+    const enumValues = ['pending', 'running', 'complete'];
+    const schema = { type: 'string', enum: enumValues };
+
+    cleanJsonSchema(schema);
+
+    expect(schema.enum).toBe(enumValues);
+  });
+
+  it('stringifies primitive enum members only for string schemas', () => {
+    const schema = { type: 'string', enum: [3, 6, 12] };
+
+    cleanJsonSchema(schema);
+
+    expect(schema.enum).toEqual(['3', '6', '12']);
+  });
+
+  it('removes non-string enums from non-string or untyped schemas and preserves their values as hints', () => {
+    const integerSchema: Record<string, unknown> = { type: 'integer', enum: [3, 6, 12] };
+    const untypedSchema: Record<string, unknown> = { enum: [true, false] };
+
+    cleanJsonSchema(integerSchema);
+    cleanJsonSchema(untypedSchema);
+
+    expect(integerSchema.enum).toBeUndefined();
+    expect(integerSchema.description).toContain('enum: 3, 6, 12');
+    expect(untypedSchema.enum).toBeUndefined();
+    expect(untypedSchema.description).toContain('enum: true, false');
+  });
+
+  it('removes malformed enums and does not coerce union-type enums', () => {
+    const malformedSchema: Record<string, unknown> = { type: 'string', enum: 'pending' };
+    const unionSchema: Record<string, unknown> = {
+      type: ['string', 'null'],
+      enum: [3, 6, 12],
+    };
+
+    cleanJsonSchema(malformedSchema);
+    cleanJsonSchema(unionSchema);
+
+    expect(malformedSchema.enum).toBeUndefined();
+    expect(unionSchema.enum).toBeUndefined();
+    expect(unionSchema.description).toContain('enum: 3, 6, 12');
+    expect(unionSchema.type).toBe('string');
+  });
+
+  it('drops non-primitive enum members without emitting empty enums', () => {
+    const stringSchema: Record<string, unknown> = { type: 'string', enum: [null, 'only'] };
+    const objectSchema: Record<string, unknown> = { enum: [{ a: 1 }] };
+
+    cleanJsonSchema(stringSchema);
+    cleanJsonSchema(objectSchema);
+
+    expect(stringSchema.enum).toEqual(['only']);
+    expect(objectSchema.enum).toBeUndefined();
+  });
+
+  it('combines enum and validation hints into one constraint suffix', () => {
+    const schema: Record<string, unknown> = {
+      type: 'integer',
+      enum: [3, 6, 12],
+      minimum: 1,
+    };
+
+    cleanJsonSchema(schema);
+
+    expect(schema.description).toContain('enum: 3, 6, 12');
+    expect(schema.description).toContain('min: 1');
+    expect((schema.description as string).match(/ \[Constraint: /g)).toHaveLength(1);
+  });
+
+  it('cleans numeric enums in nested array object properties', () => {
+    const schema: Record<string, unknown> = {
+      type: 'object',
+      properties: {
+        actions: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              delay: { type: 'integer', enum: [3, 6, 12] },
+            },
+          },
+        },
+        groups: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              nested: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    delay: { type: 'integer', enum: [3, 6, 12] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    cleanJsonSchema(schema);
+
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const actionDelay = (properties.actions.items as Record<string, Record<string, unknown>>)
+      .properties.delay as Record<string, unknown>;
+    const nestedDelay = (
+      (
+        (properties.groups.items as Record<string, Record<string, unknown>>).properties
+          .nested as Record<string, unknown>
+      ).items as Record<string, Record<string, unknown>>
+    ).properties.delay as Record<string, unknown>;
+
+    expect(actionDelay.enum).toBeUndefined();
+    expect(actionDelay.description).toContain('enum: 3, 6, 12');
+    expect(nestedDelay.enum).toBeUndefined();
+    expect(nestedDelay.description).toContain('enum: 3, 6, 12');
+  });
+
+  it('normalizes every enum member in realistic tool parameters to a string', () => {
+    const schema = normalizeObjectJsonSchema({
+      type: 'object',
+      properties: {
+        command: { type: 'string', enum: [1, 2] },
+        retry: { type: 'integer', enum: [0, 1] },
+        entries: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              mode: { type: 'string', enum: [null, 'safe'] },
+            },
+          },
+        },
+      },
+    });
+
+    const assertEnumMembersAreStrings = (value: unknown): void => {
+      if (Array.isArray(value)) {
+        value.forEach(assertEnumMembersAreStrings);
+        return;
+      }
+      if (!value || typeof value !== 'object') {
+        return;
+      }
+
+      const objectValue = value as Record<string, unknown>;
+      if (Array.isArray(objectValue.enum)) {
+        expect(objectValue.enum.every((enumValue) => typeof enumValue === 'string')).toBe(true);
+      }
+      Object.values(objectValue).forEach(assertEnumMembersAreStrings);
+    };
+
+    assertEnumMembersAreStrings(schema);
   });
 });


### PR DESCRIPTION
Gemini declares `Schema.enum` as a list of **strings**. A single numeric or boolean member
therefore fails the whole request with `Invalid value ... (TYPE_STRING)` — not just that one
field, the entire tool call — and the caller sees a schema error for a schema that is valid JSON
Schema.

The sanitizer now keeps the enum only where Gemini can accept it: a string schema keeps it with
stringified members, and every other declared type drops the enum and carries the allowed values
in the description hint the sanitizer already builds for downgraded constraints. Generated
arguments keep their declared type instead of arriving as strings.

## Verification

- `npx vitest run src/tests/unit/json-schema-utils.test.ts` — 9 passed.
- `npx eslint .` — 0 errors, 8 warnings (same 8 as the base).
- `npx prettier --check .` — clean.

Mutation: disabling the enum branch turns the new cases red with
`expected [ 3, 6, 12 ] to deeply equal [ '3', '6', '12' ]` and
`expected [ 3, 6, 12 ] to be undefined` — the two halves of the rule, one per declared type.

## The second commit

`format.yaml` runs on pull requests to `main` but not on pushes to it, so formatting drift on
`main` only surfaces on the next PR — and it did, on `src/modules/account/ipc/handler.ts` and
`src/tests/unit/antigravity-credential-store-write.test.ts`. The second commit is
`prettier --write` on exactly those two files, nothing else, so this branch's own gate is
readable. #259 carries the identical commit; whichever of the two lands first makes the other a
no-op.
