### PR TITLE
Keep the Antigravity CLI on the account the IDE switched to

### DIFF
--- a/src/modules/cloud-account/persistence/agyCliTokenStore.ts
+++ b/src/modules/cloud-account/persistence/agyCliTokenStore.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import { logger } from '@/shared/logging/logger';
+import { getAgyCliTokenPaths } from '@/shared/platform/paths';
+
+function writeTokenFile(target: string, payload: string): void {
+  const tempPath = `${target}.agm-tmp`;
+  fs.writeFileSync(tempPath, payload, { encoding: 'utf-8', mode: 0o600 });
+  fs.renameSync(tempPath, target);
+}
+
+/**
+ * Puts the active account into the Antigravity CLI (`agy`) session file.
+ *
+ * The IDE reads its token from the system credential store, but the CLI reads
+ * the very same payload from a file, so an account switch that only touches
+ * the credential store leaves the CLI signed in as somebody else. The payload
+ * is passed in already built to guarantee both stay byte-identical.
+ *
+ * Every target is best-effort: a CLI install that cannot be written must not
+ * fail the switch the IDE already accepted.
+ */
+export function writeAgyCliToken(payload: string): void {
+  const targets = getAgyCliTokenPaths();
+  if (targets.length === 0) {
+    logger.debug('No Antigravity CLI install found; skipping CLI token write');
+    return;
+  }
+
+  for (const target of targets) {
+    try {
+      writeTokenFile(target, payload);
+      logger.info(`Wrote Antigravity CLI token to ${target}`);
+    } catch (error) {
+      logger.warn(`Failed to write the Antigravity CLI token to ${target}`, error);
+    }
+  }
+}

--- a/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
+++ b/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
@@ -2,6 +2,7 @@ import { Entry } from '@napi-rs/keyring';
 import { execFileSync, spawnSync } from 'child_process';
 import { z } from 'zod';
 import { logger } from '@/shared/logging/logger';
+import { writeAgyCliToken } from './agyCliTokenStore';
 
 export interface CredentialStoreTokenInput {
   access_token: string;
@@ -260,6 +261,14 @@ export function writeAntigravityCredentialStoreToken(token: CredentialStoreToken
   const payload = buildCredentialStorePayload(token);
   logger.info('Writing Antigravity token to system credential store');
 
+  writeToSystemCredentialStore(payload);
+
+  // The CLI keeps the same payload in a file rather than the credential store,
+  // so it has to be updated here or it stays on the previous account.
+  writeAgyCliToken(payload);
+}
+
+function writeToSystemCredentialStore(payload: string): void {
   if (process.platform === 'darwin') {
     const value = `go-keyring-base64:${Buffer.from(payload, 'utf-8').toString('base64')}`;
     execFileSync(

--- a/src/shared/platform/paths.ts
+++ b/src/shared/platform/paths.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import findProcess, { type ProcessInfo } from 'find-process';
 import type { AntigravityAppTarget } from '@/modules/account/types';
 import { resolveAntigravityAppTarget } from '@/modules/account/types';
+import { detectAgyCliExecutablePath } from '@/modules/antigravity-runtime/binary-patch/agyCliPathDetection';
 
 type PathApi = Pick<typeof path, 'dirname' | 'join' | 'normalize' | 'resolve'>;
 
@@ -738,6 +739,183 @@ export function getBackupsDir(options?: PathResolutionOptions): string {
 
 export function getCloudAccountsDbPath(options?: PathResolutionOptions): string {
   return getCurrentPlatformPathApi(options).join(getAgentDir(options), 'cloud_accounts.db');
+}
+
+const AGY_CLI_DIR_SEGMENTS = ['.gemini', 'antigravity-cli'] as const;
+const AGY_CLI_TOKEN_FILE = 'antigravity-oauth-token';
+const WSL_DISTRO_CACHE_TTL_MS = 60_000;
+
+// A remote WSL share cannot answer for its own PATH, so a system-wide install
+// there is matched against the locations `agy` is actually distributed to,
+// rather than a full PATH scan like the local host gets.
+const AGY_CLI_WSL_HOME_EXECUTABLE_SEGMENTS = ['.local', 'bin', 'agy'] as const;
+const AGY_CLI_WSL_SYSTEM_EXECUTABLE_SEGMENTS: readonly (readonly string[])[] = [
+  ['usr', 'local', 'bin', 'agy'],
+  ['usr', 'bin', 'agy'],
+];
+
+let cachedRunningWslDistros: { names: string[]; readAt: number } | null = null;
+
+/**
+ * Lists the WSL distributions that are already running on this Windows host.
+ *
+ * Deliberately `--running` rather than every registered distribution: reading
+ * `\\wsl.localhost\<distro>` starts a stopped distribution, and waking WSL
+ * behind the user's back to refresh a token is a worse trade than letting the
+ * CLI there pick up the account on the next switch. The answer is cached
+ * briefly because automatic account rotation calls this in bursts.
+ *
+ * @param {NodeJS.Platform} platform The platform to answer for, so the caller's
+ * resolved platform stays the single source of truth rather than the machine
+ * this happens to run on.
+ */
+function getRunningWslDistros(platform: NodeJS.Platform): string[] {
+  if (platform !== 'win32') {
+    return [];
+  }
+
+  const now = Date.now();
+  if (cachedRunningWslDistros && now - cachedRunningWslDistros.readAt < WSL_DISTRO_CACHE_TTL_MS) {
+    return cachedRunningWslDistros.names;
+  }
+
+  let names: string[] = [];
+  try {
+    // wsl.exe answers in UTF-16LE for a Windows caller but in UTF-8 through
+    // interop, so decode by what the bytes actually look like.
+    const raw = execSync('wsl.exe -l -q --running', {
+      encoding: 'buffer',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+    const text = raw.includes(0) ? raw.toString('utf16le') : raw.toString('utf-8');
+    names = text
+      .split(/\r?\n/)
+      .map((line) => line.replace(/\0/g, '').trim())
+      .filter((line) => line.length > 0);
+  } catch {
+    // No WSL, or wsl.exe refused to answer: no distributions to serve.
+    names = [];
+  }
+
+  cachedRunningWslDistros = { names, readAt: now };
+  return names;
+}
+
+function listWslHomeDirs(distroRoot: string): string[] {
+  const homes = [path.win32.join(distroRoot, 'root')];
+
+  try {
+    const entries = fs.readdirSync(path.win32.join(distroRoot, 'home'), { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        homes.push(path.win32.join(distroRoot, 'home', entry.name));
+      }
+    }
+  } catch {
+    // A distribution without a readable /home contributes nothing.
+  }
+
+  return homes;
+}
+
+/**
+ * Whether a WSL distribution's home has an `agy` executable reachable from
+ * this share: the user-local install, or one of the system-wide locations
+ * `agy` is actually distributed to. See the doc comment on
+ * `getAgyCliTokenPaths()` for why this cannot fall back to a `PATH` scan.
+ */
+function hasWslAgyCliExecutable(
+  exists: (candidatePath: string) => boolean,
+  distroRoot: string,
+  home: string,
+): boolean {
+  if (exists(path.win32.join(home, ...AGY_CLI_WSL_HOME_EXECUTABLE_SEGMENTS))) {
+    return true;
+  }
+
+  return AGY_CLI_WSL_SYSTEM_EXECUTABLE_SEGMENTS.some((segments) =>
+    exists(path.win32.join(distroRoot, ...segments)),
+  );
+}
+
+export interface GetAgyCliTokenPathsOptions {
+  exists?: (candidatePath: string) => boolean;
+  homeDirectory?: string;
+  listRunningWslDistros?: () => string[];
+  listWslHomeDirsForDistro?: (distroRoot: string) => string[];
+  pathEnvironment?: string;
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Token files of the Antigravity CLI (`agy`) this machine can write.
+ *
+ * The CLI keeps its session in a plain file instead of the credential store
+ * the IDE reads, and a Windows host can also reach the copies inside its
+ * running WSL distributions. Two separate conditions gate each candidate:
+ *
+ * 1. `agy` is actually installed there — for the local host, detected the
+ *    same way `detectAgyCliExecutablePath()` is (user-local `~/.local/bin/agy`
+ *    first, then `PATH`); for a WSL home, a remote share cannot answer for
+ *    its own `PATH`, so the check instead matches `~/.local/bin/agy` plus the
+ *    handful of system-wide locations `agy` is actually distributed to
+ *    (`/usr/local/bin`, `/usr/bin`).
+ * 2. The session directory (`~/.gemini/antigravity-cli`) already exists —
+ *    `agy` creates it on first login, so its absence means the CLI is
+ *    installed but was never signed in. Writing there would fail with ENOENT
+ *    on every account switch, and the function must not create the directory
+ *    itself: the point is to keep CLI installs on the same account as the
+ *    IDE, not to provision the CLI where it was never set up.
+ *
+ * Every dependency is overridable through `options` so the unit suite can
+ * exercise this without touching the real home directory or spawning
+ * `wsl.exe` - production call sites invoke it with no options.
+ */
+export function getAgyCliTokenPaths(options: GetAgyCliTokenPathsOptions = {}): string[] {
+  const platform = options.platform ?? process.platform;
+  const localPathApi = platform === 'win32' ? path.win32 : path.posix;
+  const homeDirectory = options.homeDirectory ?? os.homedir();
+  const exists = options.exists ?? ((candidatePath: string) => fs.existsSync(candidatePath));
+  const pathEnvironment = options.pathEnvironment ?? process.env.PATH;
+  const listRunningWslDistros =
+    options.listRunningWslDistros ?? (() => getRunningWslDistros(platform));
+  const listWslHomeDirsForDistro = options.listWslHomeDirsForDistro ?? listWslHomeDirs;
+
+  const paths: string[] = [];
+
+  const localExecutablePath = detectAgyCliExecutablePath({
+    exists,
+    homeDirectory,
+    pathEnvironment,
+    platform,
+  });
+  if (localExecutablePath) {
+    const sessionDir = localPathApi.join(homeDirectory, ...AGY_CLI_DIR_SEGMENTS);
+    if (exists(sessionDir)) {
+      appendUniquePath(paths, localPathApi.join(sessionDir, AGY_CLI_TOKEN_FILE));
+    }
+  }
+
+  if (platform === 'win32') {
+    for (const distro of listRunningWslDistros()) {
+      const distroRoot = `\\\\wsl.localhost\\${distro}`;
+      for (const home of listWslHomeDirsForDistro(distroRoot)) {
+        if (!hasWslAgyCliExecutable(exists, distroRoot, home)) {
+          continue;
+        }
+
+        const sessionDir = path.win32.join(home, ...AGY_CLI_DIR_SEGMENTS);
+        if (!exists(sessionDir)) {
+          continue;
+        }
+
+        appendUniquePath(paths, path.win32.join(sessionDir, AGY_CLI_TOKEN_FILE));
+      }
+    }
+  }
+
+  return paths;
 }
 
 export function getAntigravityDbPaths(

--- a/src/tests/unit/agy-cli-token-store.test.ts
+++ b/src/tests/unit/agy-cli-token-store.test.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pathsMock = vi.hoisted(() => ({
+  getAgyCliTokenPaths: vi.fn<() => string[]>(() => []),
+}));
+
+vi.mock('@/shared/platform/paths', () => ({
+  getAgyCliTokenPaths: pathsMock.getAgyCliTokenPaths,
+}));
+
+vi.mock('@/shared/logging/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+const PAYLOAD = JSON.stringify({
+  token: {
+    access_token: 'access-1',
+    token_type: 'Bearer',
+    refresh_token: 'refresh-1',
+    expiry: '2026-08-13T20:39:51.237000Z',
+  },
+  auth_method: 'consumer',
+});
+
+describe('writeAgyCliToken', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-token-'));
+    pathsMock.getAgyCliTokenPaths.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('writes the payload to every CLI install', async () => {
+    const first = path.join(workDir, 'first-token');
+    const second = path.join(workDir, 'second-token');
+    pathsMock.getAgyCliTokenPaths.mockReturnValue([first, second]);
+
+    const { writeAgyCliToken } =
+      await import('../../modules/cloud-account/persistence/agyCliTokenStore');
+    writeAgyCliToken(PAYLOAD);
+
+    expect(fs.readFileSync(first, 'utf-8')).toBe(PAYLOAD);
+    expect(fs.readFileSync(second, 'utf-8')).toBe(PAYLOAD);
+  });
+
+  it('replaces an existing session in place', async () => {
+    const target = path.join(workDir, 'token');
+    fs.writeFileSync(target, 'previous account');
+    pathsMock.getAgyCliTokenPaths.mockReturnValue([target]);
+
+    const { writeAgyCliToken } =
+      await import('../../modules/cloud-account/persistence/agyCliTokenStore');
+    writeAgyCliToken(PAYLOAD);
+
+    expect(fs.readFileSync(target, 'utf-8')).toBe(PAYLOAD);
+    // The temporary file must not survive the swap.
+    expect(fs.readdirSync(workDir)).toEqual(['token']);
+  });
+
+  it('keeps going when one install cannot be written', async () => {
+    const unwritable = path.join(workDir, 'missing-dir', 'token');
+    const reachable = path.join(workDir, 'token');
+    pathsMock.getAgyCliTokenPaths.mockReturnValue([unwritable, reachable]);
+
+    const { writeAgyCliToken } =
+      await import('../../modules/cloud-account/persistence/agyCliTokenStore');
+
+    expect(() => writeAgyCliToken(PAYLOAD)).not.toThrow();
+    expect(fs.readFileSync(reachable, 'utf-8')).toBe(PAYLOAD);
+  });
+
+  it('does nothing when no CLI install is present', async () => {
+    pathsMock.getAgyCliTokenPaths.mockReturnValue([]);
+
+    const { writeAgyCliToken } =
+      await import('../../modules/cloud-account/persistence/agyCliTokenStore');
+    writeAgyCliToken(PAYLOAD);
+
+    expect(fs.readdirSync(workDir)).toEqual([]);
+  });
+});

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -5,12 +5,19 @@ const mocks = vi.hoisted(() => ({
   setSecret: vi.fn(),
   deleteCredential: vi.fn(),
   withTarget: vi.fn(),
+  writeAgyCliToken: vi.fn(),
 }));
 
 vi.mock('@napi-rs/keyring', () => ({
   Entry: {
     withTarget: mocks.withTarget,
   },
+}));
+
+// The real writer targets the Antigravity CLI session file under the user's
+// home, so leaving it unmocked would sign the live CLI out mid-test-run.
+vi.mock('@/modules/cloud-account/persistence/agyCliTokenStore', () => ({
+  writeAgyCliToken: mocks.writeAgyCliToken,
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -41,6 +48,7 @@ describe('writeAntigravityCredentialStoreToken', () => {
     mocks.setSecret.mockReset();
     mocks.deleteCredential.mockReset();
     mocks.withTarget.mockReset();
+    mocks.writeAgyCliToken.mockReset();
     mocks.withTarget.mockReturnValue({
       setSecret: mocks.setSecret,
       deleteCredential: mocks.deleteCredential,

--- a/src/tests/unit/paths.test.ts
+++ b/src/tests/unit/paths.test.ts
@@ -824,3 +824,153 @@ describe('Path Utilities', () => {
     expect(paths.getAntigravityExecutablePath('classic')).toBe(executablePath);
   });
 });
+
+describe('getAgyCliTokenPaths', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    setPlatform(originalPlatform);
+  });
+
+  it('offers the local Antigravity CLI token when the executable is installed and it has a session', async () => {
+    setPlatform('linux');
+    const exists = (candidate: string) =>
+      ['/home/alice/.local/bin/agy', '/home/alice/.gemini/antigravity-cli'].includes(candidate);
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({ exists, homeDirectory: '/home/alice', platform: 'linux' }),
+    ).toEqual(['/home/alice/.gemini/antigravity-cli/antigravity-oauth-token']);
+  });
+
+  it('does not offer a CLI token path when the CLI is installed but was never signed in', async () => {
+    setPlatform('linux');
+    // The executable exists, but agy creates the session directory only on
+    // first login, so a fresh install has neither the directory nor a token.
+    const exists = (candidate: string) => candidate === '/home/alice/.local/bin/agy';
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({ exists, homeDirectory: '/home/alice', platform: 'linux' }),
+    ).toEqual([]);
+  });
+
+  it('offers no Antigravity CLI token when the CLI was never installed', async () => {
+    setPlatform('linux');
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({
+        exists: () => false,
+        homeDirectory: '/home/alice',
+        platform: 'linux',
+      }),
+    ).toEqual([]);
+  });
+
+  it('reaches the Antigravity CLI inside running WSL distributions from Windows', async () => {
+    setPlatform('win32');
+    const exists = (candidate: string) =>
+      [
+        'C:\\Users\\Alice\\.local\\bin\\agy.exe',
+        'C:\\Users\\Alice\\.gemini\\antigravity-cli',
+        '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\.local\\bin\\agy',
+        '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\.gemini\\antigravity-cli',
+      ].includes(candidate);
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({
+        exists,
+        homeDirectory: 'C:\\Users\\Alice',
+        listRunningWslDistros: () => ['Ubuntu-24.04'],
+        listWslHomeDirsForDistro: (distroRoot) => [
+          `${distroRoot}\\root`,
+          `${distroRoot}\\home\\alice`,
+        ],
+        platform: 'win32',
+      }),
+    ).toEqual([
+      'C:\\Users\\Alice\\.gemini\\antigravity-cli\\antigravity-oauth-token',
+      '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\.gemini\\antigravity-cli\\antigravity-oauth-token',
+    ]);
+  });
+
+  it('reaches a WSL distribution where agy is installed system-wide, outside ~/.local/bin', async () => {
+    setPlatform('win32');
+    // agy lives in /usr/local/bin, not ~/.local/bin, but the distro still has
+    // a session directory for alice.
+    const exists = (candidate: string) =>
+      [
+        '\\\\wsl.localhost\\Ubuntu-24.04\\usr\\local\\bin\\agy',
+        '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\.gemini\\antigravity-cli',
+      ].includes(candidate);
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({
+        exists,
+        homeDirectory: 'C:\\Users\\Alice',
+        listRunningWslDistros: () => ['Ubuntu-24.04'],
+        listWslHomeDirsForDistro: (distroRoot) => [`${distroRoot}\\home\\alice`],
+        platform: 'win32',
+      }),
+    ).toEqual([
+      '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\.gemini\\antigravity-cli\\antigravity-oauth-token',
+    ]);
+  });
+
+  it('skips a running WSL distribution without an agy executable', async () => {
+    setPlatform('win32');
+    const exists = (candidate: string) =>
+      candidate === 'C:\\Users\\Alice\\.local\\bin\\agy.exe' ||
+      candidate === 'C:\\Users\\Alice\\.gemini\\antigravity-cli';
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({
+        exists,
+        homeDirectory: 'C:\\Users\\Alice',
+        listRunningWslDistros: () => ['Ubuntu-24.04'],
+        listWslHomeDirsForDistro: (distroRoot) => [`${distroRoot}\\home\\alice`],
+        platform: 'win32',
+      }),
+    ).toEqual(['C:\\Users\\Alice\\.gemini\\antigravity-cli\\antigravity-oauth-token']);
+  });
+
+  it('does not create a token path for a directory that has no CLI install', async () => {
+    setPlatform('linux');
+
+    const paths = await import('../../shared/platform/paths');
+
+    const exists = vi.fn(() => false);
+    expect(
+      paths.getAgyCliTokenPaths({ exists, homeDirectory: '/home/alice', platform: 'linux' }),
+    ).toEqual([]);
+    // Only presence checks happened - nothing was written or created.
+    expect(exists).toHaveBeenCalled();
+  });
+
+  it('never wakes a stopped WSL distribution: only --running distros are scanned', async () => {
+    setPlatform('win32');
+    const listRunningWslDistros = vi.fn(() => []);
+
+    const paths = await import('../../shared/platform/paths');
+
+    expect(
+      paths.getAgyCliTokenPaths({
+        exists: () => true,
+        homeDirectory: 'C:\\Users\\Alice',
+        listRunningWslDistros,
+        platform: 'win32',
+      }),
+    ).toEqual(['C:\\Users\\Alice\\.gemini\\antigravity-cli\\antigravity-oauth-token']);
+    expect(listRunningWslDistros).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/unit/security-migration.test.ts
+++ b/src/tests/unit/security-migration.test.ts
@@ -21,6 +21,9 @@ const keyringMock = vi.hoisted(() => ({
   setSecret: vi.fn(),
   withTarget: vi.fn(),
 }));
+// The real writer targets the Antigravity CLI session file under the user's
+// home, so leaving it unmocked signs the live CLI out mid-test-run.
+const agyCliMock = vi.hoisted(() => ({ writeAgyCliToken: vi.fn() }));
 
 vi.mock('electron', () => ({
   safeStorage: {
@@ -60,6 +63,10 @@ vi.mock('@napi-rs/keyring', () => ({
   Entry: {
     withTarget: keyringMock.withTarget,
   },
+}));
+
+vi.mock('@/modules/cloud-account/persistence/agyCliTokenStore', () => ({
+  writeAgyCliToken: agyCliMock.writeAgyCliToken,
 }));
 
 const fsMock = vi.mocked(fs, { deep: true });
@@ -117,6 +124,7 @@ beforeEach(async () => {
   keyringMock.deleteCredential.mockReset();
   keyringMock.setSecret.mockReset();
   keyringMock.withTarget.mockReset();
+  agyCliMock.writeAgyCliToken.mockReset();
   keyringMock.withTarget.mockReturnValue({
     deleteCredential: keyringMock.deleteCredential,
     setSecret: keyringMock.setSecret,
@@ -328,5 +336,17 @@ describe('writeAntigravityCredentialStoreToken', () => {
     writeAntigravityCredentialStoreToken(token);
 
     expect(keyringMock.setSecret).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands the credential store payload to the Antigravity CLI unchanged', async () => {
+    setPlatform('win32');
+
+    const { writeAntigravityCredentialStoreToken } =
+      await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
+
+    writeAntigravityCredentialStoreToken(token);
+
+    const secret = keyringMock.setSecret.mock.calls[0]?.[0] as Buffer;
+    expect(agyCliMock.writeAgyCliToken).toHaveBeenCalledWith(secret.toString('utf-8'));
   });
 });


### PR DESCRIPTION
The manager switches cloud accounts by writing the token into the system credential store, which
is where the Antigravity **IDE** reads it. The CLI (`agy`) reads the very same payload from a file,
`~/.gemini/antigravity-cli/antigravity-oauth-token`, and nothing writes that file — so switching
accounts in the manager left the CLI signed in as whoever last logged in there by hand.

The writer now runs alongside the credential-store write, built from **the payload already
constructed for the IDE**, so the two cannot drift. A Windows host also serves the CLI installs
inside its **running** WSL distributions over `\\wsl.localhost`, which is the case that motivated
this: the manager runs on Windows while `agy` runs in WSL. Stopped distributions are skipped on
purpose — reading their share starts them, and waking WSL to refresh a token is a worse trade than
letting that CLI pick up the account on the next switch.

Only directories that already exist are written, and every target is best-effort: this keeps
existing CLI installs in sync, it does not provision the CLI, and a CLI that cannot be written must
not fail a switch the IDE already accepted.

## The part that bit us

The writer touches a file under the user's home, and an unmocked test **signed the developer out of
`agy`**. The resolver therefore takes its directory as an explicit parameter and the suite mocks
the writer where it reaches it. No environment-variable override: the cause gets fixed, the symptom
does not get a knob.

## Verification

- `npx tsc --noEmit` — no new errors (the one pre-existing `rendererRecovery.ts` error from #257 is
  untouched).
- `npx eslint .` — 0 errors, 8 warnings, the same 8 as the base.
- `npx prettier --check .` — clean on the tracked tree.
- Touched suites — `agy-cli-token-store.test.ts`, `antigravity-credential-store-write.test.ts`,
  `security-migration.test.ts`, `paths.test.ts` — 49 passed. `paths.test.ts` carries two failures on
  this base that predate the branch: they assert a plain-Linux install while the code correctly
  resolves the Windows build under WSL. #259 fixes exactly those two.

Mutations run: building the CLI body separately from the IDE payload, making one unwritable target
throw, and writing where no CLI is installed — each fails its test and was reverted.

The second commit is `prettier --write` on two files this branch does not otherwise touch;
`format.yaml` does not run on pushes to `main`, so their drift only surfaces on the next PR. #259
and #260 carry the identical commit — whichever lands first makes the others a no-op.
