### PR TITLE
Key SignatureStore by tool-call id so parallel calls stop sharing a slot

### DIFF
--- a/src/modules/account/ipc/handler.ts
+++ b/src/modules/account/ipc/handler.ts
@@ -33,7 +33,10 @@ import {
 } from '@/modules/identity-profile/ipc/handler';
 import { runWithSwitchGuard } from '@/modules/antigravity-runtime/switch/switchGuard';
 import { executeSwitchFlow } from '@/modules/antigravity-runtime/switch/switchFlow';
-import { loadAccountIndex, saveAccountIndex } from '@/modules/account/persistence/account-index-store';
+import {
+  loadAccountIndex,
+  saveAccountIndex,
+} from '@/modules/account/persistence/account-index-store';
 import { shell } from 'electron';
 import { withTimingTrace } from '@/shared/observability/timingTrace';
 

--- a/src/modules/proxy-gateway/antigravity/ClaudeRequestMapper.ts
+++ b/src/modules/proxy-gateway/antigravity/ClaudeRequestMapper.ts
@@ -49,6 +49,24 @@ type RequestType = 'agent' | 'web_search' | 'image_gen';
 const AGENT_CREDIT_TYPES = ['GOOGLE_ONE_AI'];
 const TOOL_SCHEMA_CACHE_LIMIT = 100;
 const TOOL_SCHEMA_CACHE_TTL_MS = 30 * 60 * 1000;
+const PLACEHOLDER_SIGNATURE = 'skip_thought_signature_validator';
+
+let placeholderSignatureUsageCount = 0;
+
+/**
+ * How often the proxy fell back to the placeholder instead of a real thought
+ * signature, counted once per request that used it at least once (not once per
+ * tool call). This is the metric that tells us whether SignatureStore misses
+ * remain common on live traffic.
+ */
+export function getPlaceholderSignatureUsageCount(): number {
+  return placeholderSignatureUsageCount;
+}
+
+/** Test-only: resets the module-level placeholder counter between assertions. */
+export function resetPlaceholderSignatureUsageCount(): void {
+  placeholderSignatureUsageCount = 0;
+}
 const SAFETY_SETTINGS: SafetySetting[] = [
   { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'OFF' },
   { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'OFF' },
@@ -683,6 +701,7 @@ function buildContents(
 ): GeminiContent[] {
   const contents: GeminiContent[] = [];
   let lastThoughtSignature: string | null = null;
+  let placeholderUsage: { model: string; toolCallId: string } | null = null;
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
@@ -721,6 +740,7 @@ function buildContents(
         toolIdToName.set(block.id, block.name);
         const finalSig =
           block.signature ||
+          SignatureStore.getForToolCall(block.id) ||
           lastThoughtSignature ||
           SignatureStore.getAt(signatureSessionKey, i) ||
           SignatureStore.get(signatureSessionKey);
@@ -728,8 +748,9 @@ function buildContents(
           part.thoughtSignature = finalSig;
           part.thought_signature = finalSig;
         } else if (isThinkingEnabled && modelKeepsThinkingWithoutSignature(mappedModel)) {
-          part.thoughtSignature = 'skip_thought_signature_validator';
-          part.thought_signature = 'skip_thought_signature_validator';
+          part.thoughtSignature = PLACEHOLDER_SIGNATURE;
+          part.thought_signature = PLACEHOLDER_SIGNATURE;
+          placeholderUsage ??= { model: mappedModel, toolCallId: block.id };
         }
         parts.push(part);
       } else if (block.type === 'tool_result') {
@@ -767,6 +788,14 @@ function buildContents(
     }
     if (parts.length > 0) contents.push({ role, parts });
   }
+
+  if (placeholderUsage) {
+    placeholderSignatureUsageCount++;
+    logger.warn(
+      `[Signature-Placeholder] No real thought signature available, replaying '${PLACEHOLDER_SIGNATURE}' for model=${placeholderUsage.model} toolCallId=${placeholderUsage.toolCallId}`,
+    );
+  }
+
   return contents;
 }
 

--- a/src/modules/proxy-gateway/antigravity/ClaudeResponseMapper.ts
+++ b/src/modules/proxy-gateway/antigravity/ClaudeResponseMapper.ts
@@ -61,9 +61,6 @@ class NonStreamingProcessor {
 
   private processPart(part: GeminiPart) {
     const signature = decodeSignature(part.thoughtSignature ?? part.thought_signature) || null;
-    if (signature) {
-      SignatureStore.store(signature, this.signatureSessionKey, this.signatureMessageCount);
-    }
 
     // 1. Handle FunctionCall
     if (part.functionCall) {
@@ -85,6 +82,15 @@ class NonStreamingProcessor {
       const fc = part.functionCall;
       const toolId = fc.id || `${fc.name}-${uuidv4()}`;
 
+      if (signature) {
+        SignatureStore.store(
+          signature,
+          this.signatureSessionKey,
+          this.signatureMessageCount,
+          toolId,
+        );
+      }
+
       const toolUse: ContentBlock = {
         type: 'tool_use',
         id: toolId,
@@ -95,6 +101,10 @@ class NonStreamingProcessor {
 
       this.contentBlocks.push(toolUse);
       return;
+    }
+
+    if (signature) {
+      SignatureStore.store(signature, this.signatureSessionKey, this.signatureMessageCount);
     }
 
     // 2. Handle Text / Thinking

--- a/src/modules/proxy-gateway/antigravity/ClaudeStreamingMapper.ts
+++ b/src/modules/proxy-gateway/antigravity/ClaudeStreamingMapper.ts
@@ -491,7 +491,12 @@ export class PartProcessor {
     if (signature) {
       toolUse.signature = signature;
       // Store signature to global storage for replay in subsequent requests
-      SignatureStore.store(signature, this.state.signatureSessionKey, this.state.messageCount);
+      SignatureStore.store(
+        signature,
+        this.state.signatureSessionKey,
+        this.state.messageCount,
+        toolId,
+      );
     }
 
     chunks.push(...this.state.startBlock('Function', toolUse));

--- a/src/modules/proxy-gateway/antigravity/SignatureStore.ts
+++ b/src/modules/proxy-gateway/antigravity/SignatureStore.ts
@@ -3,6 +3,12 @@
  *
  * Clients that provide a stable session identifier are isolated from one another.
  * Requests without one preserve the legacy shared-signature behavior.
+ *
+ * Entries are additionally indexed by tool-call id, independent of session key.
+ * A tool-call id is unique per conversation, so keying on it directly is the only
+ * way to guarantee that two tool calls issued concurrently on the same session (or
+ * on the legacy no-session-key path, where storage would otherwise be one shared
+ * slot) never read each other's signature back on replay.
  */
 import { logger } from '@/shared/logging/logger';
 
@@ -24,6 +30,7 @@ class SignatureStoreImpl {
 
   private signature: string | null = null;
   private readonly signaturesBySession = new Map<string, SessionSignatureBucket>();
+  private readonly signaturesByToolCallId = new Map<string, StoredSignature>();
 
   private constructor() {}
 
@@ -37,10 +44,16 @@ class SignatureStoreImpl {
   /**
    * Stores a signature, preferring the longest value because streaming chunks can
    * contain partial signatures. A supplied session key prevents cross-session reuse.
+   * A supplied tool-call id additionally makes the signature retrievable by that id
+   * alone via {@link getForToolCall}, regardless of session key.
    */
-  public store(sig: string, sessionKey?: string, messageCount?: number): void {
+  public store(sig: string, sessionKey?: string, messageCount?: number, toolCallId?: string): void {
     if (!sig) {
       return;
+    }
+
+    if (toolCallId) {
+      this.storeByToolCallId(sig, toolCallId);
     }
 
     if (!sessionKey) {
@@ -134,6 +147,25 @@ class SignatureStoreImpl {
   }
 
   /**
+   * Get the signature stored for a specific tool-call id, independent of session key.
+   * A miss (no entry, or an expired one) returns null; it is a normal outcome, not an error.
+   */
+  public getForToolCall(toolCallId: string | undefined): string | null {
+    if (!toolCallId) {
+      return null;
+    }
+    const stored = this.signaturesByToolCallId.get(toolCallId);
+    if (!stored) {
+      return null;
+    }
+    if (Date.now() - stored.updatedAt >= SignatureStoreImpl.SESSION_TTL_MS) {
+      this.signaturesByToolCallId.delete(toolCallId);
+      return null;
+    }
+    return stored.signature;
+  }
+
+  /**
    * Get the signature produced for the assistant message at an exact conversation index.
    */
   public getAt(sessionKey: string | undefined, messageCount: number): string | null {
@@ -175,6 +207,35 @@ class SignatureStoreImpl {
     }
     this.signature = null;
     this.signaturesBySession.clear();
+    this.signaturesByToolCallId.clear();
+  }
+
+  private storeByToolCallId(sig: string, toolCallId: string): void {
+    this.evictExpiredToolCallEntries();
+    const existingLen = this.signaturesByToolCallId.get(toolCallId)?.signature.length ?? 0;
+    if (sig.length > existingLen) {
+      this.signaturesByToolCallId.set(toolCallId, { signature: sig, updatedAt: Date.now() });
+    }
+    this.evictOverflowToolCallEntries();
+  }
+
+  private evictExpiredToolCallEntries(): void {
+    const oldestAllowed = Date.now() - SignatureStoreImpl.SESSION_TTL_MS;
+    for (const [toolCallId, stored] of this.signaturesByToolCallId.entries()) {
+      if (stored.updatedAt < oldestAllowed) {
+        this.signaturesByToolCallId.delete(toolCallId);
+      }
+    }
+  }
+
+  private evictOverflowToolCallEntries(): void {
+    while (this.signaturesByToolCallId.size > SignatureStoreImpl.MAX_SESSION_ENTRIES) {
+      const oldestToolCallId = this.signaturesByToolCallId.keys().next().value;
+      if (!oldestToolCallId) {
+        return;
+      }
+      this.signaturesByToolCallId.delete(oldestToolCallId);
+    }
   }
 
   private evictExpiredSessions(): void {

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -65,14 +65,7 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
     expect(mocks.execFileSync).toHaveBeenCalledWith(
       'security',
-      expect.arrayContaining([
-        'add-generic-password',
-        '-s',
-        'gemini',
-        '-a',
-        'antigravity',
-        '-U',
-      ]),
+      expect.arrayContaining(['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-U']),
       { stdio: 'ignore' },
     );
     expect(mocks.execFileSync.mock.calls[0][1]).not.toContain('delete-generic-password');

--- a/src/tests/unit/thought-signature-compatibility.test.ts
+++ b/src/tests/unit/thought-signature-compatibility.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { transformClaudeRequestIn } from '@/modules/proxy-gateway/antigravity/ClaudeRequestMapper';
+import {
+  transformClaudeRequestIn,
+  getPlaceholderSignatureUsageCount,
+  resetPlaceholderSignatureUsageCount,
+} from '@/modules/proxy-gateway/antigravity/ClaudeRequestMapper';
 import { transformResponse } from '@/modules/proxy-gateway/antigravity/ClaudeResponseMapper';
 import {
   PartProcessor,
@@ -15,6 +19,7 @@ const SKIP_THOUGHT_SIGNATURE = 'skip_thought_signature_validator';
 describe('thought signature compatibility', () => {
   afterEach(() => {
     SignatureStore.clear();
+    resetPlaceholderSignatureUsageCount();
   });
 
   it('sends both signature field names for thinking, function calls, and tool results', () => {
@@ -100,6 +105,7 @@ describe('thought signature compatibility', () => {
         thought_signature: SKIP_THOUGHT_SIGNATURE,
       },
     ]);
+    expect(getPlaceholderSignatureUsageCount()).toBe(1);
   });
 
   it('accepts snake-case signatures from non-streaming Gemini responses', () => {
@@ -272,5 +278,72 @@ describe('thought signature compatibility', () => {
     });
 
     expect(SignatureStore.getAt(sessionKey, 5)).toBe(THOUGHT_SIGNATURE);
+  });
+
+  it("keeps concurrent tool calls in the same turn from reading each other's signature", () => {
+    const sessionKey = 'anthropic:parallel-tool-calls';
+
+    // Two tool calls produced in the same assistant turn (same message count), each with
+    // its own signature. The longer one is what the legacy session+messageCount bucket
+    // would keep, so a fallback keyed only by that bucket would replay it for both calls.
+    const shortCallSignature = 'sig-for-call-a-' + 'x'.repeat(20);
+    const longCallSignature = 'sig-for-call-b-' + 'y'.repeat(60);
+
+    transformResponse(
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: { name: 'tool_a', args: {}, id: 'call_a' },
+                  thoughtSignature: shortCallSignature,
+                },
+                {
+                  functionCall: { name: 'tool_b', args: {}, id: 'call_b' },
+                  thoughtSignature: longCallSignature,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      sessionKey,
+      9,
+    );
+
+    expect(SignatureStore.getForToolCall('call_a')).toBe(shortCallSignature);
+    expect(SignatureStore.getForToolCall('call_b')).toBe(longCallSignature);
+
+    // Replay: a client that echoes tool_use blocks back without their signature must
+    // still get each call's own signature, not the other call's.
+    const request: ClaudeRequest = {
+      model: 'gemini-3-flash',
+      max_tokens: 1024,
+      thinking: { type: 'enabled', budget_tokens: 256 },
+      metadata: { signature_session_key: sessionKey },
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'call_a', name: 'tool_a', input: {} },
+            { type: 'tool_use', id: 'call_b', name: 'tool_b', input: {} },
+          ],
+        },
+      ],
+    };
+
+    const body = transformClaudeRequestIn(request);
+    const functionCallParts = body.request.contents[0].parts.filter((part) => part.functionCall);
+
+    expect(functionCallParts[0]?.thoughtSignature).toBe(shortCallSignature);
+    expect(functionCallParts[1]?.thoughtSignature).toBe(longCallSignature);
+  });
+
+  it('returns null instead of throwing when no signature was ever stored for a tool-call id', () => {
+    expect(() => SignatureStore.getForToolCall('never-stored-call-id')).not.toThrow();
+    expect(SignatureStore.getForToolCall('never-stored-call-id')).toBeNull();
+    expect(SignatureStore.getForToolCall(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
`SignatureStore` remembers thinking signatures so a replayed tool call carries the signature the
model produced. It is keyed by an optional client-supplied `signatureSessionKey` plus an
assistant-turn index, with a single shared field as the legacy fallback when no session key is
present — so **any two tool calls landing in the same turn share one storage slot**, and on the
legacy path any two concurrent requests do. `store()` kept the longest signature seen for that
slot, so on replay every tool call in the turn got whichever signature happened to be stored last,
not its own.

The fix adds a second, independent index keyed by tool-call id alone, which is unique per
conversation. It is populated wherever a tool-call id is available (`fc.id` in the streaming and
response mappers, `block.id` in the request mapper's `buildContents`) and consulted before the
existing session/turn fallback on replay. The old paths are untouched, so the single-call behaviour
is unchanged; a miss returns `null` — it never throws and never fabricates a placeholder that later
reads as a real signature. The new index is bounded by the same 500-entry / 1h TTL as the existing
map.

## A note on where this came from

A fix for the same underlying defect exists on another line of this repository, described there as
"keyed by account". That premise does not hold here: this branch's store has no account concept at
all, and the collision is by turn, not by account. The rule was ported, not the patch — the other
line's version depends on a request-mapper split that does not exist here, and smuggling that split
in under a bug-fix label would have been the wrong trade.

## Verification

- `npx tsc --noEmit` — no new errors (the one pre-existing `rendererRecovery.ts` error from #257 is
  untouched).
- `npx eslint .` — 0 errors, 8 warnings, the same 8 as the base.
- `npx prettier --check .` — clean on the tracked tree.
- `thought-signature-compatibility.test.ts`, `proxy-retry-mock.test.ts`,
  `openai-responses-streaming-mapper.test.ts` — 57 passed.

Mutations run: keying by turn again reproduces the cross-call collision, and making a miss throw or
fabricate a placeholder fails its test. Both reverted.

The last commit is `prettier --write` on two files this branch does not otherwise touch;
`format.yaml` does not run on pushes to `main`, so their drift only surfaces on the next PR.
