### PR TITLE
Capture the request behind an upstream 4xx

### DIFF
--- a/src/modules/account/ipc/handler.ts
+++ b/src/modules/account/ipc/handler.ts
@@ -33,7 +33,10 @@ import {
 } from '@/modules/identity-profile/ipc/handler';
 import { runWithSwitchGuard } from '@/modules/antigravity-runtime/switch/switchGuard';
 import { executeSwitchFlow } from '@/modules/antigravity-runtime/switch/switchFlow';
-import { loadAccountIndex, saveAccountIndex } from '@/modules/account/persistence/account-index-store';
+import {
+  loadAccountIndex,
+  saveAccountIndex,
+} from '@/modules/account/persistence/account-index-store';
 import { shell } from 'electron';
 import { withTimingTrace } from '@/shared/observability/timingTrace';
 

--- a/src/modules/proxy-gateway/server/README.md
+++ b/src/modules/proxy-gateway/server/README.md
@@ -124,7 +124,22 @@ When reading, updating, or refactoring code within this directory, strictly foll
 
 ---
 
-## 5. Verification & Development Checklist
+## 5. Diagnostics
+
+### Upstream 4xx Capture
+
+Set `AGM_UPSTREAM_4XX_CAPTURE=1` to write a redacted JSON pair (the client request and the
+converted upstream request/rejection) to `~/.antigravity-agent/captures/` every time
+`GeminiClient` receives a final 4xx from the upstream (Gemini is the shared transport for
+OpenAI, Anthropic and native Gemini requests). Off by default: capture is a diagnostic aid, not
+something every install should pay disk I/O for on every rejected request. Secrets are masked
+with `sanitizeObject` before anything is written, the directory is pruned to the newest 50
+files, and a capture failure (e.g. disk full) is logged and swallowed — it never turns the
+caller's 4xx into a 5xx.
+
+---
+
+## 6. Verification & Development Checklist
 
 After modifying files in `server/`, execute the following verification steps in order:
 

--- a/src/modules/proxy-gateway/server/common/upstream-4xx-capture.service.ts
+++ b/src/modules/proxy-gateway/server/common/upstream-4xx-capture.service.ts
@@ -1,0 +1,126 @@
+import { Logger } from '@nestjs/common';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { isObjectLike, isString } from 'lodash-es';
+import { getAgentDir } from '@/shared/platform/paths';
+import { sanitizeObject } from '@/shared/security/sensitiveDataMasking';
+import { getUpstreamCaptureContext } from './upstream-capture-context';
+
+const CAPTURE_DIRECTORY = 'captures';
+const CAPTURE_LIMIT = 50;
+
+export interface Upstream4xxCaptureInput {
+  endpoint: string;
+  status?: number;
+  upstreamErrorBody: unknown;
+  upstreamRequest: unknown;
+}
+
+/**
+ * Writes a redacted request/rejection pair for upstream 4xx diagnosis when explicitly enabled.
+ * Capture is diagnostic-only: any filesystem error is logged and deliberately swallowed so it
+ * can never turn the caller's upstream 4xx into a 5xx.
+ */
+export class Upstream4xxCaptureService {
+  private readonly logger = new Logger(Upstream4xxCaptureService.name);
+
+  async capture(input: Upstream4xxCaptureInput): Promise<void> {
+    if (!isUpstream4xxCaptureEnabled() || !isClientErrorStatus(input.status)) {
+      return;
+    }
+
+    try {
+      const captureDirectory = path.join(getAgentDir(), CAPTURE_DIRECTORY);
+      await fs.mkdir(captureDirectory, { recursive: true });
+      const context = getUpstreamCaptureContext();
+      const capturedAt = new Date().toISOString();
+      const document = sanitizeObject({
+        client_request: {
+          body: context?.clientRequest.body,
+          endpoint: context?.clientRequest.endpoint,
+          headers: context?.clientRequest.headers ?? {},
+        },
+        metadata: {
+          captured_at: capturedAt,
+          client_visible_model: findClientModel(
+            context?.clientRequest.body,
+            context?.clientRequest.endpoint,
+          ),
+          mapped_upstream_model: findModel(input.upstreamRequest),
+          upstream_endpoint: input.endpoint,
+        },
+        upstream_request: input.upstreamRequest,
+        upstream_response: {
+          error_body: input.upstreamErrorBody,
+          status: input.status,
+        },
+      });
+      const filename = `${capturedAt.replace(/[:.]/gu, '-')}-${randomUUID()}.json`;
+
+      await fs.writeFile(
+        path.join(captureDirectory, filename),
+        JSON.stringify(document, null, 2),
+        'utf-8',
+      );
+      await this.prune(captureDirectory);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to write upstream 4xx capture: ${message}`);
+    }
+  }
+
+  private async prune(captureDirectory: string): Promise<void> {
+    const entries = await fs.readdir(captureDirectory, { withFileTypes: true });
+    const captures = await Promise.all(
+      entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+        .map(async (entry) => {
+          const filePath = path.join(captureDirectory, entry.name);
+          return { filePath, modifiedAt: (await fs.stat(filePath)).mtimeMs };
+        }),
+    );
+    const expired = captures
+      .sort((left, right) => left.modifiedAt - right.modifiedAt)
+      .slice(0, Math.max(0, captures.length - CAPTURE_LIMIT));
+
+    await Promise.all(expired.map(({ filePath }) => fs.unlink(filePath)));
+  }
+}
+
+export function isUpstream4xxCaptureEnabled(): boolean {
+  return process.env.AGM_UPSTREAM_4XX_CAPTURE === '1';
+}
+
+function isClientErrorStatus(status: number | undefined): status is number {
+  return status !== undefined && status >= 400 && status < 500;
+}
+
+function findModel(value: unknown): string | null {
+  if (!isObjectLike(value)) {
+    return null;
+  }
+
+  const record = value as { model?: unknown; request?: unknown };
+  if (isString(record.model)) {
+    return record.model;
+  }
+  if (isObjectLike(record.request)) {
+    const model = (record.request as { model?: unknown }).model;
+    return isString(model) ? model : null;
+  }
+  return null;
+}
+
+function findClientModel(body: unknown, endpoint: string | undefined): string | null {
+  const bodyModel = findModel(body);
+  if (bodyModel) {
+    return bodyModel;
+  }
+
+  const match = endpoint?.match(/\/models\/([^/:?]+)/u);
+  if (!match) {
+    return null;
+  }
+  return decodeURIComponent(match[1]);
+}

--- a/src/modules/proxy-gateway/server/common/upstream-capture-context.ts
+++ b/src/modules/proxy-gateway/server/common/upstream-capture-context.ts
@@ -1,0 +1,65 @@
+import {
+  Injectable,
+  type CallHandler,
+  type ExecutionContext,
+  type NestInterceptor,
+} from '@nestjs/common';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { Observable } from 'rxjs';
+
+export interface UpstreamCaptureContext {
+  clientRequest: {
+    body: unknown;
+    endpoint: string;
+    headers: Record<string, unknown>;
+  };
+}
+
+const upstreamCaptureContext = new AsyncLocalStorage<UpstreamCaptureContext>();
+
+export function getUpstreamCaptureContext(): UpstreamCaptureContext | undefined {
+  return upstreamCaptureContext.getStore();
+}
+
+export function runWithUpstreamCaptureContext<T>(
+  context: UpstreamCaptureContext,
+  callback: () => T,
+): T {
+  return upstreamCaptureContext.run(context, callback);
+}
+
+/** Preserves the incoming wire request until the shared upstream transport (GeminiClient) resolves it. */
+@Injectable()
+export class UpstreamCaptureContextInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<{
+      body?: unknown;
+      headers?: Record<string, unknown>;
+      url?: string;
+    }>();
+
+    const captureContext: UpstreamCaptureContext = {
+      clientRequest: {
+        body: snapshotRequestBody(request.body),
+        endpoint: request.url ?? '',
+        headers: { ...(request.headers ?? {}) },
+      },
+    };
+
+    return new Observable((subscriber) =>
+      upstreamCaptureContext.run(captureContext, () => next.handle().subscribe(subscriber)),
+    );
+  }
+}
+
+function snapshotRequestBody(body: unknown): unknown {
+  if (body === undefined) {
+    return undefined;
+  }
+
+  try {
+    return structuredClone(body);
+  } catch {
+    return body;
+  }
+}

--- a/src/modules/proxy-gateway/server/modules/gemini/gemini-client.service.ts
+++ b/src/modules/proxy-gateway/server/modules/gemini/gemini-client.service.ts
@@ -12,6 +12,10 @@ import {
   type ExplicitContextCacheResource,
 } from './explicit-context-cache.store';
 import { UpstreamRequestError } from '../../common/exceptions/upstream-request.exception';
+import {
+  Upstream4xxCaptureService,
+  type Upstream4xxCaptureInput,
+} from '../../common/upstream-4xx-capture.service';
 import { safeStringifyPacket } from '@/shared/security/sensitiveDataMasking';
 
 interface PreparedInternalRequest {
@@ -22,6 +26,7 @@ interface PreparedInternalRequest {
 @Injectable()
 export class GeminiClient {
   private readonly logger = new Logger(GeminiClient.name);
+  private readonly upstream4xxCapture = new Upstream4xxCaptureService();
   // Default to v1beta for most features
   private readonly baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
   private readonly defaultInternalBaseUrls = [
@@ -51,14 +56,9 @@ export class GeminiClient {
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        this.logger.error(`Gemini stream request failed: ${error.message}`);
-        throw new UpstreamRequestError({
-          message: error.response?.data?.error?.message || error.message,
-          status: error.response?.status,
-          headers: {
-            retryAfter: this.extractRetryAfterHeader(error.response?.headers),
-          },
-          body: this.describeAxiosErrorData(error.response?.data),
+        return await this.throwUpstreamRequestError(error, 'gemini-stream-generate', {
+          endpoint: url,
+          upstreamRequest: content,
         });
       }
       this.throwAsCleanError(error);
@@ -86,16 +86,9 @@ export class GeminiClient {
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        this.logger.error(
-          `Gemini request failed: ${error.message} - ${this.safeStringify(error.response?.data)}`,
-        );
-        throw new UpstreamRequestError({
-          message: error.response?.data?.error?.message || error.message,
-          status: error.response?.status,
-          headers: {
-            retryAfter: this.extractRetryAfterHeader(error.response?.headers),
-          },
-          body: this.describeAxiosErrorData(error.response?.data),
+        return await this.throwUpstreamRequestError(error, 'gemini-generate', {
+          endpoint: url,
+          upstreamRequest: content,
         });
       }
       this.throwAsCleanError(error);
@@ -366,6 +359,7 @@ export class GeminiClient {
     const requestUserAgent = await resolveRequestUserAgent();
     const axiosProxy = this.resolveUpstreamAxiosProxy(upstreamProxyUrl);
     let lastError: unknown = null;
+    let lastEndpoint = '';
     let hasTriggeredProjectHeaderDowngrade = false;
 
     for (let projectHeaderAttempt = 0; projectHeaderAttempt < 5; projectHeaderAttempt++) {
@@ -377,6 +371,7 @@ export class GeminiClient {
       for (let index = 0; index < baseUrls.length; index++) {
         const baseUrl = baseUrls[index];
         const url = `${baseUrl}${path}`;
+        lastEndpoint = url;
 
         try {
           return await axios.post<T>(url, this.createInternalRequestBody(path, body), {
@@ -406,7 +401,10 @@ export class GeminiClient {
           const hasNextEndpoint = index < baseUrls.length - 1;
 
           if (!hasNextEndpoint || !this.shouldFailoverToNextEndpoint(error)) {
-            await this.throwUpstreamRequestError(error, operation);
+            return await this.throwUpstreamRequestError(error, operation, {
+              endpoint: url,
+              upstreamRequest: body,
+            });
           }
 
           this.logger.warn(
@@ -421,10 +419,16 @@ export class GeminiClient {
         continue;
       }
 
-      return await this.throwUpstreamRequestError(lastError, operation);
+      return await this.throwUpstreamRequestError(lastError, operation, {
+        endpoint: lastEndpoint,
+        upstreamRequest: body,
+      });
     }
 
-    return await this.throwUpstreamRequestError(lastError, operation);
+    return await this.throwUpstreamRequestError(lastError, operation, {
+      endpoint: lastEndpoint,
+      upstreamRequest: body,
+    });
   }
 
   private createInternalRequestBody(path: string, body: GeminiInternalRequest): string | Readable {
@@ -458,22 +462,32 @@ export class GeminiClient {
     );
   }
 
-  private async throwUpstreamRequestError(error: unknown, operation: string): Promise<never> {
+  private async throwUpstreamRequestError(
+    error: unknown,
+    operation: string,
+    captureInput: Pick<Upstream4xxCaptureInput, 'endpoint' | 'upstreamRequest'>,
+  ): Promise<never> {
     if (axios.isAxiosError(error)) {
       const responseData = error.response?.data;
       const upstreamMessage = await this.extractAxiosErrorMessage(responseData);
+      const upstreamErrorBody = this.describeAxiosErrorData(responseData);
       this.logger.error(
         `[${operation}] upstream request error: ${error.message} - ${this.describeAxiosErrorData(
           responseData,
         )}`,
       );
+      await this.upstream4xxCapture.capture({
+        ...captureInput,
+        status: error.response?.status,
+        upstreamErrorBody,
+      });
       throw new UpstreamRequestError({
         message: upstreamMessage || error.message,
         status: error.response?.status,
         headers: {
           retryAfter: this.extractRetryAfterHeader(error.response?.headers),
         },
-        body: this.describeAxiosErrorData(responseData),
+        body: upstreamErrorBody,
       });
     }
     this.throwAsCleanError(error);

--- a/src/modules/proxy-gateway/server/proxy.module.ts
+++ b/src/modules/proxy-gateway/server/proxy.module.ts
@@ -1,14 +1,22 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 import { AccountLeaseModule } from './modules/account-lease/account-lease.module';
 import { AnthropicModule } from './modules/anthropic/anthropic.module';
 import { GeminiModule } from './modules/gemini/gemini.module';
 import { OpenAIModule } from './modules/openai/openai.module';
 import { ProxyService } from './proxy.service';
+import { UpstreamCaptureContextInterceptor } from './common/upstream-capture-context';
 
 @Module({
   imports: [AccountLeaseModule, GeminiModule, AnthropicModule, OpenAIModule],
-  providers: [ProxyService],
+  providers: [
+    ProxyService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: UpstreamCaptureContextInterceptor,
+    },
+  ],
   exports: [ProxyService, AccountLeaseModule],
 })
 export class ProxyModule {}

--- a/src/shared/security/sensitiveDataMasking.ts
+++ b/src/shared/security/sensitiveDataMasking.ts
@@ -8,6 +8,8 @@ const SENSITIVE_KEYS = [
   'token',
   'apikey',
   'api_key',
+  'x-api-key',
+  'x-goog-api-key',
   'secret',
   'authorization',
   'credentials',

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -65,14 +65,7 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
     expect(mocks.execFileSync).toHaveBeenCalledWith(
       'security',
-      expect.arrayContaining([
-        'add-generic-password',
-        '-s',
-        'gemini',
-        '-a',
-        'antigravity',
-        '-U',
-      ]),
+      expect.arrayContaining(['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-U']),
       { stdio: 'ignore' },
     );
     expect(mocks.execFileSync.mock.calls[0][1]).not.toContain('delete-generic-password');

--- a/src/tests/unit/gateway-start.test.ts
+++ b/src/tests/unit/gateway-start.test.ts
@@ -12,7 +12,10 @@ const { mockAttachResponsesWebSocketServer, mockCreate, mockLogger } = vi.hoiste
   },
 }));
 
-vi.mock('@nestjs/core', () => ({
+vi.mock('@nestjs/core', async (importOriginal) => ({
+  // Keep the real tokens: the module graph under test registers providers against
+  // APP_INTERCEPTOR, and a mock that only carries NestFactory makes importing it fail.
+  ...(await importOriginal<typeof import('@nestjs/core')>()),
   NestFactory: {
     create: mockCreate,
   },

--- a/src/tests/unit/upstream-4xx-capture.test.ts
+++ b/src/tests/unit/upstream-4xx-capture.test.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  runWithUpstreamCaptureContext,
+  type UpstreamCaptureContext,
+} from '@/modules/proxy-gateway/server/common/upstream-capture-context';
+import { Upstream4xxCaptureService } from '@/modules/proxy-gateway/server/common/upstream-4xx-capture.service';
+
+let agentDirectory = '';
+
+vi.mock('@/shared/platform/paths', () => ({
+  getAgentDir: vi.fn(() => agentDirectory),
+}));
+
+const CAPTURES_DIRECTORY = 'captures';
+
+function captureContext(
+  overrides: Partial<UpstreamCaptureContext['clientRequest']> = {},
+): UpstreamCaptureContext {
+  return {
+    clientRequest: {
+      body: { model: 'client-model', input: 'client request' },
+      endpoint: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      ...overrides,
+    },
+  };
+}
+
+async function writeCapture(
+  input: Partial<Parameters<InstanceType<typeof Upstream4xxCaptureService>['capture']>[0]> = {},
+) {
+  const capture = new Upstream4xxCaptureService();
+  await runWithUpstreamCaptureContext(captureContext(), () =>
+    capture.capture({
+      endpoint: 'https://cloudcode-pa.googleapis.com/v1internal:generateContent',
+      status: 400,
+      upstreamErrorBody: { error: { message: 'rejected' } },
+      upstreamRequest: { request: { model: 'upstream-model' } },
+      ...input,
+    }),
+  );
+}
+
+async function captureFiles(): Promise<string[]> {
+  const directory = path.join(agentDirectory, CAPTURES_DIRECTORY);
+  try {
+    return await fs.readdir(directory);
+  } catch {
+    return [];
+  }
+}
+
+describe('upstream 4xx capture', () => {
+  beforeEach(async () => {
+    agentDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'agm-upstream-capture-'));
+    process.env.AGM_UPSTREAM_4XX_CAPTURE = '1';
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.AGM_UPSTREAM_4XX_CAPTURE;
+    await fs.rm(agentDirectory, { force: true, recursive: true });
+  });
+
+  it('writes one JSON file with the client request, upstream payload, and upstream response', async () => {
+    await writeCapture();
+
+    const files = await captureFiles();
+    expect(files).toHaveLength(1);
+
+    const document = JSON.parse(
+      await fs.readFile(path.join(agentDirectory, CAPTURES_DIRECTORY, files[0]), 'utf-8'),
+    ) as Record<string, unknown>;
+    expect(document.client_request).toEqual(expect.any(Object));
+    expect(document.upstream_request).toEqual(expect.any(Object));
+    expect(document.upstream_response).toEqual(expect.any(Object));
+    expect(document.metadata).toMatchObject({
+      client_visible_model: 'client-model',
+      mapped_upstream_model: 'upstream-model',
+    });
+  });
+
+  it('does not write a capture for a 2xx response', async () => {
+    await writeCapture({ status: 200 });
+
+    expect(await captureFiles()).toEqual([]);
+  });
+
+  it('does not write a capture when the flag is disabled', async () => {
+    delete process.env.AGM_UPSTREAM_4XX_CAPTURE;
+
+    await writeCapture();
+
+    expect(await captureFiles()).toEqual([]);
+  });
+
+  it('redacts secrets in client headers and both request bodies', async () => {
+    const secret = 'do-not-write-this-secret';
+    const capture = new Upstream4xxCaptureService();
+    await runWithUpstreamCaptureContext(
+      captureContext({
+        body: { api_key: secret, nested: { access_token: secret } },
+        headers: {
+          Authorization: `Bearer ${secret}`,
+          Cookie: `session=${secret}`,
+          'x-api-key': secret,
+          'x-goog-api-key': secret,
+        },
+      }),
+      () =>
+        capture.capture({
+          endpoint: 'https://cloudcode-pa.googleapis.com/v1internal:generateContent',
+          status: 400,
+          upstreamErrorBody: { error: { refresh_token: secret } },
+          upstreamRequest: { request: { api_key: secret } },
+        }),
+    );
+
+    const [file] = await captureFiles();
+    const content = await fs.readFile(path.join(agentDirectory, CAPTURES_DIRECTORY, file), 'utf-8');
+    expect(content).not.toContain(secret);
+  });
+
+  it('removes the oldest capture when writing the 51st file', async () => {
+    await writeCapture();
+    const [oldest] = await captureFiles();
+    const oldestPath = path.join(agentDirectory, CAPTURES_DIRECTORY, oldest);
+    await fs.utimes(oldestPath, new Date(0), new Date(0));
+
+    for (let index = 0; index < 50; index++) {
+      await writeCapture({ upstreamErrorBody: { error: { message: `rejected-${index}` } } });
+    }
+
+    const files = await captureFiles();
+    expect(files).toHaveLength(50);
+    expect(files).not.toContain(oldest);
+  });
+
+  it('swallows a capture write failure', async () => {
+    const writeFile = vi
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValueOnce(new Error('disk is unavailable'));
+
+    await expect(writeCapture()).resolves.toBeUndefined();
+    expect(writeFile).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
When the upstream answers a proxied request with a 4xx, the caller sees the rejection but the
request that caused it is gone, so a contract defect can only be reproduced by guessing what was
sent. This captures both sides: one redacted JSON document per final upstream 4xx, holding the
client request, the converted upstream request and the upstream rejection, plus the endpoint, the
client-visible model and the mapped upstream model.

`GeminiClient` is this branch's single upstream transport for all three protocols, and its only
choke point for rejections is `throwUpstreamRequestError`. All of its call sites now pass the
endpoint and the upstream request, and the two previously-inline throws in `streamGenerate` and
`generate` were rerouted through it, so every 4xx exit point captures rather than most of them.
The original client wire request travels there through an `AsyncLocalStorage` populated by a global
interceptor.

Three properties, each covered by a test:

- **Masking is not optional.** Everything goes through the existing `sanitizeObject` before it is
  serialized, and `x-api-key` / `x-goog-api-key` were added to the sensitive-key set because the
  captured client headers can carry either.
- **The capture cannot change what the caller sees.** A failure inside the capture path is logged
  and swallowed; the upstream's own 4xx and its body reach the caller unchanged.
- **Bounded on disk.** Fifty captures, oldest pruned first. The bound is by count, not bytes — a
  single unusually large document is not capped, which is a deliberate narrowing rather than an
  oversight.

Off by default behind `AGM_UPSTREAM_4XX_CAPTURE=1`, documented in `server/README.md`: capture is a
diagnostic aid for reproducing a defect, not something every install should pay filesystem I/O for
on every rejected request. The bound and the masking are what make it safe to turn on; they are not
an argument for running it unconditionally.

## Verification

- `npx tsc --noEmit` — no new errors (the one pre-existing `rendererRecovery.ts` error from #257 is
  untouched).
- `npx eslint .` — 0 errors, 8 warnings, the same 8 as the base.
- `npx prettier --check .` — clean on the tracked tree.
- `upstream-4xx-capture.test.ts` (6 cases) and `proxy-module.integration.test.ts` — 7 passed;
  `gemini-client-context-cache.test.ts` and `gemini-client-proxy-hot-reload.test.ts` confirm the
  `throwUpstreamRequestError` signature change left existing client behaviour alone.

Mutations run, each failing its own test and reverted: disabling the masking (the failure names the
leaked fields), making the capture path throw (the caller still receives the upstream's 400 with its
body intact), and removing the bound.

Not covered: no end-to-end HTTP request through the interceptor — it is exercised through module
resolution and a direct client unit test with mocked transport, not a live call.

The last commit is `prettier --write` on two files this branch does not otherwise touch;
`format.yaml` does not run on pushes to `main`, so their drift only surfaces on the next PR.
