### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ Please submit issues or suggestions via [GitHub Issues](https://github.com/Dracu
 
 <a href="https://github.com/Draculabo/AntigravityManager/stargazers">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Draculabo/AntigravityManager&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Draculabo/AntigravityManager&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Draculabo/AntigravityManager&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Draculabo/AntigravityManager&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Draculabo/AntigravityManager&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Draculabo/AntigravityManager&type=Date" />
   </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -373,9 +373,9 @@ codesign --force --deep --sign - "/Applications/Antigravity Manager 2.app"
 
 <a href="https://github.com/Draculabo/AntigravityManager/stargazers">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Draculabo/AntigravityManager&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Draculabo/AntigravityManager&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Draculabo/AntigravityManager&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Draculabo/AntigravityManager&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Draculabo/AntigravityManager&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Draculabo/AntigravityManager&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on our README is currently broken due to GitHub stargazer API restrictions. This change points the chart at an alternative that uses another data source and requires no API token, restoring a working star history chart on both the English and Chinese READMEs.