### PR TITLE
fix(cloud-account): alert when model quota reaches zero

### DIFF
--- a/src/modules/cloud-account/services/CloudMonitorService.ts
+++ b/src/modules/cloud-account/services/CloudMonitorService.ts
@@ -291,7 +291,9 @@ export class CloudMonitorService {
         for (const account of accounts) {
           if (!account.quota?.models) continue;
           const lowQuotaModels = Object.entries(account.quota.models)
-            .filter(([_, info]) => info.percentage <= alertThreshold && info.percentage > 0)
+            .filter(
+              ([_, info]) => info.percentage >= 0 && info.percentage <= alertThreshold,
+            )
             .map(([name, info]) => {
               return info.display_name || name.replace('models/', '').replace(/-/g, ' ');
             });

--- a/src/tests/unit/cloud-monitor-zero-quota-alert.test.ts
+++ b/src/tests/unit/cloud-monitor-zero-quota-alert.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as electronMock from 'electron';
+import { CloudMonitorService } from '@/modules/cloud-account/services/CloudMonitorService';
+import { CloudAccountRepo } from '@/modules/cloud-account/persistence/cloudHandler';
+import { CloudAccountSettingsStore } from '@/modules/cloud-account/persistence/cloud-account-settings-store';
+import { GoogleAPIService } from '@/modules/cloud-account/services/GoogleAPIService';
+
+vi.mock('@/modules/cloud-account/persistence/cloudHandler');
+vi.mock('@/modules/cloud-account/persistence/cloud-account-settings-store');
+vi.mock('@/modules/cloud-account/services/GoogleAPIService');
+vi.mock('@/modules/cloud-account/services/AutoSwitchService');
+vi.mock('@/shared/logging/logger');
+
+describe('CloudMonitorService exhausted quota alerts', () => {
+  let notificationShowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    CloudMonitorService.resetStateForTesting();
+    notificationShowSpy = vi.spyOn(
+      (electronMock as { Notification: typeof electronMock.Notification }).Notification.prototype,
+      'show',
+    );
+
+    vi.mocked(CloudAccountSettingsStore.getSetting).mockImplementation(
+      (key: string, fallback: unknown) => {
+        if (key === 'quota_alert_enabled') return true;
+        if (key === 'quota_alert_threshold') return 20;
+        if (key === 'ai_credits_alert_enabled') return false;
+        if (key === 'language') return 'en';
+        return fallback;
+      },
+    );
+    vi.mocked(GoogleAPIService.fetchAICredits).mockResolvedValue(null as never);
+  });
+
+  afterEach(() => {
+    CloudMonitorService.stop();
+    notificationShowSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('alerts when a model quota reaches zero percent', async () => {
+    vi.mocked(CloudAccountRepo.getAccounts).mockResolvedValue([
+      {
+        id: 'acc-zero',
+        email: 'zero@example.com',
+        token: {
+          access_token: 'access-token',
+          expiry_timestamp: Math.floor(Date.now() / 1000) + 3600,
+        },
+      },
+    ] as never);
+    vi.mocked(GoogleAPIService.fetchQuota).mockResolvedValue({
+      models: {
+        'models/gemini-test': {
+          display_name: 'Gemini Test',
+          percentage: 0,
+        },
+      },
+    } as never);
+
+    const pollPromise = CloudMonitorService.poll();
+    await vi.advanceTimersByTimeAsync(1000);
+    await pollPromise;
+
+    expect(notificationShowSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- include models at 0% quota in low-quota notifications
- keep negative quota percentages excluded from alerts
- add regression coverage for an exhausted model quota

## Why

The existing filter only alerts when quota is greater than 0%, so a model stops generating notifications exactly when its quota is fully exhausted. This change keeps exhausted models inside the configured low-quota threshold.

## Validation

- `npm test -- src/tests/unit/cloud-monitor.test.ts src/tests/unit/cloud-monitor-zero-quota-alert.test.ts` — 2 test files passed, 18 tests passed