### PR TITLE
fix(cloud-account): stop inventing IDE token expiry

### DIFF
--- a/src/modules/cloud-account/persistence/ide-account-import-adapter.ts
+++ b/src/modules/cloud-account/persistence/ide-account-import-adapter.ts
@@ -15,6 +15,7 @@ import { ItemTableValueRowSchema } from '@/shared/persistence/database/types';
 import { parseRow } from '@/shared/persistence/database/sqlite';
 import { ProtobufUtils } from '@/shared/serialization/protobuf';
 import { CloudAccountRepo } from './cloudHandler';
+import { resolveImportedTokenLifetime } from './ide-token-lifetime';
 
 export const AGY_SYNC_FROM_IDE_UNSUPPORTED_MESSAGE =
   'Antigravity CLI accounts are stored in the system credential store and cannot be synced from IDE SQLite state.';
@@ -259,6 +260,7 @@ export class IdeAccountImportAdapter {
 
       logger.info(`SyncLocal: Using Antigravity database at: ${dbPath}`);
       const effectiveTokenInfo = { ...tokenInfo };
+      let refreshedExpiresIn: number | undefined;
 
       let googleUserInfo;
       try {
@@ -279,6 +281,7 @@ export class IdeAccountImportAdapter {
           effectiveTokenInfo.accessToken = refreshedToken.access_token;
           effectiveTokenInfo.refreshToken = refreshedToken.refresh_token || tokenInfo.refreshToken;
           effectiveTokenInfo.idToken = refreshedToken.id_token ?? tokenInfo.idToken;
+          refreshedExpiresIn = refreshedToken.expires_in;
           googleUserInfo = await GoogleAPIService.getUserInfo(effectiveTokenInfo.accessToken);
         } catch (refreshError: unknown) {
           const refreshErrorMessage =
@@ -290,6 +293,7 @@ export class IdeAccountImportAdapter {
       }
 
       const now = Math.floor(Date.now() / 1000);
+      const tokenLifetime = resolveImportedTokenLifetime(now, refreshedExpiresIn);
       const account: CloudAccount = {
         id: uuidv4(),
         provider: 'google',
@@ -299,8 +303,8 @@ export class IdeAccountImportAdapter {
         token: {
           access_token: effectiveTokenInfo.accessToken,
           refresh_token: effectiveTokenInfo.refreshToken,
-          expires_in: 3600,
-          expiry_timestamp: now + 3600,
+          expires_in: tokenLifetime.expiresIn,
+          expiry_timestamp: tokenLifetime.expiryTimestamp,
           token_type: 'Bearer',
           email: googleUserInfo.email,
           project_id: effectiveTokenInfo.projectId,
@@ -331,8 +335,8 @@ export class IdeAccountImportAdapter {
           ...existingAccount.token,
           access_token: effectiveTokenInfo.accessToken,
           refresh_token: effectiveTokenInfo.refreshToken || existingAccount.token.refresh_token,
-          expires_in: 3600,
-          expiry_timestamp: now + 3600,
+          expires_in: tokenLifetime.expiresIn,
+          expiry_timestamp: tokenLifetime.expiryTimestamp,
           token_type: 'Bearer',
           email: googleUserInfo.email,
           project_id: existingProjectId || effectiveTokenInfo.projectId,

--- a/src/modules/cloud-account/persistence/ide-token-lifetime.ts
+++ b/src/modules/cloud-account/persistence/ide-token-lifetime.ts
@@ -1,0 +1,26 @@
+export interface ImportedTokenLifetime {
+  expiresIn: number;
+  expiryTimestamp: number;
+}
+
+export function resolveImportedTokenLifetime(
+  nowSeconds: number,
+  refreshedExpiresIn?: number,
+): ImportedTokenLifetime {
+  if (
+    typeof refreshedExpiresIn !== 'number' ||
+    !Number.isFinite(refreshedExpiresIn) ||
+    refreshedExpiresIn <= 0
+  ) {
+    return {
+      expiresIn: 0,
+      expiryTimestamp: 0,
+    };
+  }
+
+  const expiresIn = Math.floor(refreshedExpiresIn);
+  return {
+    expiresIn,
+    expiryTimestamp: nowSeconds + expiresIn,
+  };
+}

--- a/src/tests/unit/ide-token-lifetime.test.ts
+++ b/src/tests/unit/ide-token-lifetime.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { resolveImportedTokenLifetime } from '@/modules/cloud-account/persistence/ide-token-lifetime';
+
+describe('resolveImportedTokenLifetime', () => {
+  it('marks imported tokens without verified expiry as immediately refreshable', () => {
+    expect(resolveImportedTokenLifetime(1_700_000_000)).toEqual({
+      expiresIn: 0,
+      expiryTimestamp: 0,
+    });
+  });
+
+  it('uses the real lifetime returned by a successful token refresh', () => {
+    expect(resolveImportedTokenLifetime(1_700_000_000, 1800)).toEqual({
+      expiresIn: 1800,
+      expiryTimestamp: 1_700_001_800,
+    });
+  });
+
+  it('rejects invalid refreshed lifetimes instead of inventing a one hour expiry', () => {
+    expect(resolveImportedTokenLifetime(1_700_000_000, Number.NaN)).toEqual({
+      expiresIn: 0,
+      expiryTimestamp: 0,
+    });
+    expect(resolveImportedTokenLifetime(1_700_000_000, -1)).toEqual({
+      expiresIn: 0,
+      expiryTimestamp: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- stop inventing IDE token expiry
- add focused regression coverage in `src/tests/unit/ide-token-lifetime.test.ts`

## Validation

- `npm test -- src/tests/unit/ide-token-lifetime.test.ts` — passed against a temporary merge with current `main`