### PR TITLE
fix(cloud-account): avoid treating generic forbidden errors as rate limits

### DIFF
--- a/src/modules/cloud-account/utils/account-status.ts
+++ b/src/modules/cloud-account/utils/account-status.ts
@@ -64,9 +64,6 @@ export function classifyAccountStatusFromError(
     return { status: 'expired', reason };
   }
 
-  if (normalizedReason.includes('forbidden')) {
-    return { status: 'rate_limited', reason };
-  }
   if (normalizedReason.includes('unauthorized')) {
     return { status: 'expired', reason };
   }

--- a/src/tests/unit/account-status.test.ts
+++ b/src/tests/unit/account-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { classifyAccountStatusFromError } from '@/modules/cloud-account/utils/account-status';
+
+describe('classifyAccountStatusFromError', () => {
+  it('does not treat a generic forbidden response as a rate limit', () => {
+    expect(classifyAccountStatusFromError(new Error('HTTP 403: Forbidden'))).toBeNull();
+  });
+
+  it('still classifies explicit rate-limit signals', () => {
+    expect(classifyAccountStatusFromError(new Error('HTTP 403: risk control active'))).toEqual({
+      status: 'rate_limited',
+      reason: 'HTTP 403: risk control active',
+    });
+  });
+
+  it('still classifies unauthorized errors as expired credentials', () => {
+    expect(classifyAccountStatusFromError(new Error('HTTP 401: Unauthorized'))).toEqual({
+      status: 'expired',
+      reason: 'HTTP 401: Unauthorized',
+    });
+  });
+
+  it('classifies invalid_grant as requiring reauthentication', () => {
+    expect(classifyAccountStatusFromError(new Error('{"error":"invalid_grant"}'))).toEqual({
+      status: 'expired',
+      reason: '{"error":"invalid_grant"}',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- avoid treating generic forbidden errors as rate limits
- add focused regression coverage in `src/tests/unit/account-status.test.ts`

## Validation

- `npm test -- src/tests/unit/account-status.test.ts` — passed against a temporary merge with current `main`