### PR TITLE
fix(cloud-account): detect installed secret-tool without version flag

### DIFF
--- a/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
+++ b/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
@@ -222,12 +222,12 @@ export function readAntigravityCredentialStoreToken(): CredentialStoreToken | nu
   return null;
 }
 
-function isSecretToolAvailable(): boolean {
-  const versionResult = spawnSync('secret-tool', ['--version'], {
+export function isSecretToolAvailable(): boolean {
+  const probeResult = spawnSync('secret-tool', [], {
     stdio: 'ignore',
     timeout: 3000,
   });
-  return !versionResult.error && versionResult.status === 0;
+  return !probeResult.error;
 }
 
 function writeViaNativeKeyring(payload: string): void {

--- a/src/tests/unit/antigravity-credential-store-read.test.ts
+++ b/src/tests/unit/antigravity-credential-store-read.test.ts
@@ -236,4 +236,36 @@ describe('readAntigravityCredentialStoreToken', () => {
       expect(String(error)).not.toContain('refresh-secret-leak');
     }
   });
+
+  it('treats secret-tool as installed even when its usage probe exits non-zero', async () => {
+    mocks.spawnSync.mockReturnValue({
+      error: undefined,
+      status: 2,
+      stdout: '',
+      stderr: '',
+    });
+    const { isSecretToolAvailable } =
+      await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
+
+    expect(isSecretToolAvailable()).toBe(true);
+    expect(mocks.spawnSync).toHaveBeenCalledWith('secret-tool', [], {
+      stdio: 'ignore',
+      timeout: 3000,
+    });
+  });
+
+  it('treats secret-tool as unavailable when the executable cannot be spawned', async () => {
+    mocks.spawnSync.mockReturnValue({
+      error: Object.assign(new Error('spawn secret-tool ENOENT'), {
+        code: 'ENOENT',
+      }),
+      status: null,
+      stdout: '',
+      stderr: '',
+    });
+    const { isSecretToolAvailable } =
+      await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
+
+    expect(isSecretToolAvailable()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- detect installed secret-tool without version flag
- add focused regression coverage in `src/tests/unit/antigravity-credential-store-read.test.ts`

## Validation

- `npm test -- src/tests/unit/antigravity-credential-store-read.test.ts` — passed against a temporary merge with current `main`