### PR TITLE
fix(cloud-account): handle unrefreshable monitor tokens

### DIFF
--- a/src/modules/cloud-account/services/CloudMonitorService.ts
+++ b/src/modules/cloud-account/services/CloudMonitorService.ts
@@ -207,27 +207,43 @@ export class CloudMonitorService {
           // 1. Check/Refresh Token if needed (give it a 10 min buffer here for safety)
           let accessToken = account.token.access_token;
           if (account.token.expiry_timestamp < now + 600) {
-            logger.info(`Monitor: Refreshing token for ${account.email}`);
-            try {
-              const newToken = await GoogleAPIService.refreshAccessToken(
-                account.token.refresh_token,
-                account.proxy_url,
-                account.token.oauth_client_key,
-              );
-              account.token = mergeRefreshedToken(account.token, newToken, now);
-              await CloudAccountRepo.updateToken(account.id, account.token);
-              accessToken = newToken.access_token;
-            } catch (refreshError) {
-              logger.error(`Monitor: Token refresh failed for ${account.email}`, refreshError);
-              const classified = classifyAccountStatusFromError(refreshError);
-              if (classified) {
+            if (!account.token.refresh_token) {
+              if (account.token.expiry_timestamp <= now) {
+                logger.warn(`Monitor: Token expired without refresh token for ${account.email}`);
                 await CloudAccountRepo.setAccountStatus(
                   account.id,
-                  classified.status,
-                  classified.reason,
+                  'expired',
+                  'Access token expired and no refresh token is available',
                 );
+                continue;
               }
-              continue;
+
+              logger.info(
+                `Monitor: Token for ${account.email} is nearing expiry without a refresh token; using it until expiry`,
+              );
+            } else {
+              logger.info(`Monitor: Refreshing token for ${account.email}`);
+              try {
+                const newToken = await GoogleAPIService.refreshAccessToken(
+                  account.token.refresh_token,
+                  account.proxy_url,
+                  account.token.oauth_client_key,
+                );
+                account.token = mergeRefreshedToken(account.token, newToken, now);
+                await CloudAccountRepo.updateToken(account.id, account.token);
+                accessToken = newToken.access_token;
+              } catch (refreshError) {
+                logger.error(`Monitor: Token refresh failed for ${account.email}`, refreshError);
+                const classified = classifyAccountStatusFromError(refreshError);
+                if (classified) {
+                  await CloudAccountRepo.setAccountStatus(
+                    account.id,
+                    classified.status,
+                    classified.reason,
+                  );
+                }
+                continue;
+              }
             }
           }
 

--- a/src/tests/unit/cloud-monitor-unrefreshable-token.test.ts
+++ b/src/tests/unit/cloud-monitor-unrefreshable-token.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CloudMonitorService } from '@/modules/cloud-account/services/CloudMonitorService';
+import { CloudAccountRepo } from '@/modules/cloud-account/persistence/cloudHandler';
+import { GoogleAPIService } from '@/modules/cloud-account/services/GoogleAPIService';
+
+vi.mock('@/modules/cloud-account/persistence/cloudHandler');
+vi.mock('@/modules/cloud-account/persistence/cloud-account-settings-store');
+vi.mock('@/modules/cloud-account/services/GoogleAPIService');
+vi.mock('@/modules/cloud-account/services/AutoSwitchService');
+vi.mock('@/shared/logging/logger');
+
+describe('CloudMonitorService unrefreshable tokens', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-17T05:00:00Z'));
+    vi.clearAllMocks();
+    CloudMonitorService.resetStateForTesting();
+  });
+
+  afterEach(() => {
+    CloudMonitorService.stop();
+    vi.useRealTimers();
+  });
+
+  it('marks an expired token without refresh token as expired without network refresh', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    vi.mocked(CloudAccountRepo.getAccounts).mockResolvedValue([
+      {
+        id: 'expired-account',
+        email: 'expired@example.com',
+        token: {
+          access_token: 'expired-access-token',
+          expiry_timestamp: now - 1,
+        },
+      },
+    ] as never);
+
+    await CloudMonitorService.poll();
+
+    expect(GoogleAPIService.refreshAccessToken).not.toHaveBeenCalled();
+    expect(GoogleAPIService.fetchQuota).not.toHaveBeenCalled();
+    expect(CloudAccountRepo.setAccountStatus).toHaveBeenCalledWith(
+      'expired-account',
+      'expired',
+      'Access token expired and no refresh token is available',
+    );
+  });
+
+  it('uses a still-valid access token until expiry when no refresh token exists', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    vi.mocked(CloudAccountRepo.getAccounts).mockResolvedValue([
+      {
+        id: 'near-expiry-account',
+        email: 'near-expiry@example.com',
+        token: {
+          access_token: 'still-valid-access-token',
+          expiry_timestamp: now + 300,
+        },
+      },
+    ] as never);
+    vi.mocked(GoogleAPIService.fetchQuota).mockResolvedValue({ models: {} } as never);
+
+    const pollPromise = CloudMonitorService.poll();
+    await vi.advanceTimersByTimeAsync(1000);
+    await pollPromise;
+
+    expect(GoogleAPIService.refreshAccessToken).not.toHaveBeenCalled();
+    expect(GoogleAPIService.fetchQuota).toHaveBeenCalledWith(
+      'still-valid-access-token',
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- handle unrefreshable monitor tokens
- add focused regression coverage in `src/tests/unit/cloud-monitor-unrefreshable-token.test.ts`

## Validation

- `npm test -- src/tests/unit/cloud-monitor-unrefreshable-token.test.ts` — passed against a temporary merge with current `main`