### PR TITLE
fix(cloud-account): normalize auto-switch model config keys

### DIFF
--- a/src/modules/cloud-account/services/AutoSwitchService.ts
+++ b/src/modules/cloud-account/services/AutoSwitchService.ts
@@ -44,6 +44,14 @@ export class AutoSwitchService {
     return candidates[0];
   }
 
+  private static getModelConfig(
+    config: Record<string, { enabled: boolean; priority: boolean }>,
+    modelId: string,
+  ) {
+    const normalizedModelId = modelId.replace(/^models\//i, '');
+    return config[modelId] ?? config[normalizedModelId];
+  }
+
   private static calculateAccountScore(
     account: CloudAccount,
     config: Record<string, { enabled: boolean; priority: boolean }>,
@@ -54,7 +62,7 @@ export class AutoSwitchService {
 
     // 1. Get priority models that are enabled and exist in this account
     const priorityEntries = entries.filter(([modelId]) => {
-      const modelConfig = config[modelId];
+      const modelConfig = this.getModelConfig(config, modelId);
       return modelConfig?.enabled && modelConfig?.priority;
     });
 
@@ -65,7 +73,7 @@ export class AutoSwitchService {
 
     // 2. Fall back to all enabled models
     const enabledEntries = entries.filter(([modelId]) => {
-      const modelConfig = config[modelId];
+      const modelConfig = this.getModelConfig(config, modelId);
       return modelConfig ? modelConfig.enabled : true;
     });
 
@@ -142,7 +150,7 @@ export class AutoSwitchService {
       ) || {};
 
     const enabledModels = Object.entries(account.quota.models).filter(([modelId]) => {
-      const modelConfig = config[modelId];
+      const modelConfig = this.getModelConfig(config, modelId);
       return modelConfig ? modelConfig.enabled : true;
     });
 

--- a/src/tests/unit/auto-switch.test.ts
+++ b/src/tests/unit/auto-switch.test.ts
@@ -121,6 +121,65 @@ describe('AutoSwitchService', () => {
     expect(AutoSwitchService.isAccountDepleted(testAccount)).toBe(false);
   });
 
+  it('applies unprefixed model settings to prefixed quota model identifiers', async () => {
+    const { CloudAccountSettingsStore } =
+      await import('@/modules/cloud-account/persistence/cloud-account-settings-store');
+    const { AutoSwitchService } =
+      await import('@/modules/cloud-account/services/AutoSwitchService');
+
+    vi.mocked(CloudAccountSettingsStore.getSetting).mockReturnValue({
+      'claude-sonnet-4-5': { enabled: false, priority: false },
+      'gemini-pro': { enabled: true, priority: false },
+    });
+
+    const testAccount = createAccount('prefixed-models', {
+      models: {
+        'models/claude-sonnet-4-5': { percentage: 1, resetTime: '' },
+        'models/gemini-pro': { percentage: 90, resetTime: '' },
+      },
+    });
+
+    expect(AutoSwitchService.isAccountDepleted(testAccount)).toBe(false);
+  });
+
+  it('uses unprefixed priority settings when quota identifiers are prefixed', async () => {
+    const { CloudAccountRepo } = await import('@/modules/cloud-account/persistence/cloudHandler');
+    const { CloudAccountSettingsStore } =
+      await import('@/modules/cloud-account/persistence/cloud-account-settings-store');
+    const { AutoSwitchService } =
+      await import('@/modules/cloud-account/services/AutoSwitchService');
+
+    vi.mocked(CloudAccountSettingsStore.getSetting).mockReturnValue({
+      'claude-sonnet-4-5': { enabled: true, priority: true },
+      'gemini-pro': { enabled: true, priority: false },
+    });
+
+    vi.mocked(CloudAccountRepo.getAccounts).mockResolvedValue([
+      createAccount('current', {
+        models: {
+          'models/claude-sonnet-4-5': { percentage: 50, resetTime: '' },
+          'models/gemini-pro': { percentage: 90, resetTime: '' },
+        },
+      }),
+      createAccount('priority-high', {
+        models: {
+          'models/claude-sonnet-4-5': { percentage: 80, resetTime: '' },
+          'models/gemini-pro': { percentage: 10, resetTime: '' },
+        },
+      }),
+      createAccount('priority-low', {
+        models: {
+          'models/claude-sonnet-4-5': { percentage: 60, resetTime: '' },
+          'models/gemini-pro': { percentage: 95, resetTime: '' },
+        },
+      }),
+    ]);
+
+    await expect(AutoSwitchService.findBestAccount('current')).resolves.toMatchObject({
+      id: 'priority-high',
+    });
+  });
+
   it('uses the best quota in an alias group and keeps the threshold comparison strict', async () => {
     const { AutoSwitchService } =
       await import('@/modules/cloud-account/services/AutoSwitchService');


### PR DESCRIPTION
## Summary

- normalize auto-switch model config keys
- add focused regression coverage in `src/tests/unit/auto-switch.test.ts`

## Validation

- `npm test -- src/tests/unit/auto-switch.test.ts` — passed against a temporary merge with current `main`