### PR TITLE
fix(cloud-account): normalize quota group model identifiers

### DIFF
--- a/src/modules/cloud-account/services/AutoSwitchService.ts
+++ b/src/modules/cloud-account/services/AutoSwitchService.ts
@@ -201,8 +201,9 @@ export class AutoSwitchService {
           .join(' ')
           .toLowerCase();
         return enabledModels.some(([modelId]) => {
-          const modelPart = modelId.split('-')[0].toLowerCase(); // 'claude' or 'gemini' etc.
-          return groupText.includes(modelPart) || groupText.includes(modelId.toLowerCase());
+          const normalizedModelId = modelId.replace(/^models\//i, '').toLowerCase();
+          const modelPart = normalizedModelId.split('-')[0]; // 'claude' or 'gemini' etc.
+          return groupText.includes(modelPart) || groupText.includes(normalizedModelId);
         });
       });
       if (anyAffected) {

--- a/src/tests/unit/auto-switch.test.ts
+++ b/src/tests/unit/auto-switch.test.ts
@@ -148,6 +148,32 @@ describe('AutoSwitchService', () => {
     });
   });
 
+  it('matches depleted quota groups for models-prefixed identifiers', async () => {
+    const { AutoSwitchService } =
+      await import('@/modules/cloud-account/services/AutoSwitchService');
+
+    const prefixedModelAccount = createAccount('prefixed-model', {
+      models: {
+        'models/gemini-flash': { percentage: 90, resetTime: '' },
+      },
+      quota_groups: [
+        {
+          display_name: 'Gemini models',
+          buckets: [
+            {
+              bucket_id: 'gemini-group',
+              window: '5h',
+              remaining_fraction: 0.01,
+              reset_time: '',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(AutoSwitchService.isAccountDepleted(prefixedModelAccount)).toBe(true);
+  });
+
   it('prioritizes priority models during best account selection', async () => {
     const { CloudAccountRepo } = await import('@/modules/cloud-account/persistence/cloudHandler');
     const { CloudAccountSettingsStore } =


### PR DESCRIPTION
## Summary

- normalize quota group model identifiers
- add focused regression coverage in `src/tests/unit/auto-switch.test.ts`

## Validation

- `npm test -- src/tests/unit/auto-switch.test.ts` — passed against a temporary merge with current `main`