### PR TITLE
fix(cloud-account): fail OAuth callback without renderer

### DIFF
--- a/src/modules/cloud-account/ipc/authServer.ts
+++ b/src/modules/cloud-account/ipc/authServer.ts
@@ -63,14 +63,23 @@ export class AuthServer {
               `AuthServer: Received authorization code: ${escapedCode.substring(0, 10)}...`,
             );
 
-            // Send code to renderer
-            if (ipcContext.mainWindow) {
-              logger.info('AuthServer: Sending code to renderer via IPC');
-              ipcContext.mainWindow.webContents.send('GOOGLE_AUTH_CODE', code);
-              logger.info('AuthServer: Code sent successfully');
-            } else {
-              logger.error('AuthServer: Main window not found, cannot send code');
+            if (!ipcContext.mainWindow) {
+              logger.error('AuthServer: Main window not found, cannot deliver authorization code');
+              res.writeHead(503, { 'Content-Type': 'text/html; charset=utf-8' });
+              res.end(`
+            <html>
+              <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
+                <h1>Login Failed</h1>
+                <p>Antigravity Manager is not ready to receive the authorization result. Return to the app and try again.</p>
+              </body>
+            </html>
+          `);
+              return;
             }
+
+            logger.info('AuthServer: Sending code to renderer via IPC');
+            ipcContext.mainWindow.webContents.send('GOOGLE_AUTH_CODE', code);
+            logger.info('AuthServer: Code sent successfully');
 
             res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
             res.end(`

--- a/src/tests/unit/auth-server-renderer-delivery.test.ts
+++ b/src/tests/unit/auth-server-renderer-delivery.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/ipc/context', () => ({
+  ipcContext: {
+    mainWindow: undefined,
+  },
+}));
+
+vi.mock('@/shared/logging/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { AuthServer } from '@/modules/cloud-account/ipc/authServer';
+
+async function fetchCallback(url: string): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await fetch(url);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError;
+}
+
+describe('AuthServer authorization delivery', () => {
+  afterEach(async () => {
+    await AuthServer.stop();
+  });
+
+  it('does not report success when no renderer can receive the authorization code', async () => {
+    await AuthServer.start();
+
+    const response = await fetchCallback(`${AuthServer.getRedirectUri()}?code=test-code`);
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).toContain('Login Failed');
+    expect(body).not.toContain('Login Successful');
+  });
+});


### PR DESCRIPTION
## Summary

- fail OAuth callback without renderer
- add focused regression coverage in `src/tests/unit/auth-server-renderer-delivery.test.ts`

## Validation

- `npm test -- src/tests/unit/auth-server-renderer-delivery.test.ts` — passed against a temporary merge with current `main`
- `npm run type-check` — passed against the same merge