### PR TITLE
fix(cloud-account): preserve last used during account import

### DIFF
--- a/src/modules/cloud-account/ipc/handler.ts
+++ b/src/modules/cloud-account/ipc/handler.ts
@@ -958,7 +958,6 @@ export async function importCloudAccounts(
           proxy_url: importedAccount.proxy_url ?? existing.proxy_url,
           status: importedAccount.status ?? existing.status,
           status_reason: importedAccount.status_reason ?? existing.status_reason,
-          last_used: now,
         };
 
         await CloudAccountRepo.addAccount(updatedAccount);

--- a/src/tests/unit/cloud-account-import-last-used.test.ts
+++ b/src/tests/unit/cloud-account-import-last-used.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const handlerPath = path.join(
+  process.cwd(),
+  'src/modules/cloud-account/ipc/handler.ts',
+);
+
+function readImportAccountBlocks(): {
+  existingAccountBlock: string;
+  newAccountBlock: string;
+} {
+  const source = fs.readFileSync(handlerPath, 'utf8');
+  const existingStart = source.indexOf('const updatedAccount: CloudAccount = {');
+  const existingEnd = source.indexOf(
+    'await CloudAccountRepo.addAccount(updatedAccount);',
+    existingStart,
+  );
+  const newStart = source.indexOf('const newAccount: CloudAccount = {', existingEnd);
+  const newEnd = source.indexOf('await CloudAccountRepo.addAccount(newAccount);', newStart);
+
+  expect(existingStart).toBeGreaterThanOrEqual(0);
+  expect(existingEnd).toBeGreaterThan(existingStart);
+  expect(newStart).toBeGreaterThan(existingEnd);
+  expect(newEnd).toBeGreaterThan(newStart);
+
+  return {
+    existingAccountBlock: source.slice(existingStart, existingEnd),
+    newAccountBlock: source.slice(newStart, newEnd),
+  };
+}
+
+describe('cloud account import last-used semantics', () => {
+  it('preserves usage recency for existing accounts while initializing new accounts', () => {
+    const { existingAccountBlock, newAccountBlock } = readImportAccountBlocks();
+
+    expect(existingAccountBlock).toContain('...existing');
+    expect(existingAccountBlock).not.toMatch(/last_used:\s*now/);
+    expect(newAccountBlock).toMatch(/last_used:\s*now/);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve last used during account import
- add focused regression coverage in `src/tests/unit/cloud-account-import-last-used.test.ts`

## Validation

- `npm test -- src/tests/unit/cloud-account-import-last-used.test.ts` — passed against a temporary merge with current `main`
- `npm run type-check` — passed against the same merge