### PR TITLE
fix(cloud-account): update native keyring credentials atomically

### DIFF
--- a/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
+++ b/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
@@ -232,12 +232,6 @@ function isSecretToolAvailable(): boolean {
 
 function writeViaNativeKeyring(payload: string): void {
   const entry = Entry.withTarget('gemini:antigravity', 'gemini', 'antigravity');
-  try {
-    entry.deleteCredential();
-  } catch {
-    // Missing previous credential is acceptable.
-  }
-
   entry.setSecret(Buffer.from(payload, 'utf-8'));
 }
 

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -96,4 +96,44 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
     expect(mocks.execFileSync.mock.calls[0][1]).not.toContain('delete-generic-password');
   });
+
+  it('updates native keyring credentials without deleting the existing entry first', async () => {
+    setPlatform('win32');
+    const { writeAntigravityCredentialStoreToken } =
+      await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
+
+    writeAntigravityCredentialStoreToken({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expiry_timestamp: 1_900_000_000,
+    });
+
+    expect(mocks.withTarget).toHaveBeenCalledWith(
+      'gemini:antigravity',
+      'gemini',
+      'antigravity',
+    );
+    expect(mocks.setSecret).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteCredential).not.toHaveBeenCalled();
+  });
+
+  it('preserves the existing native keyring entry when an update fails', async () => {
+    setPlatform('win32');
+    mocks.setSecret.mockImplementation(() => {
+      throw new Error('native keyring update failed');
+    });
+    const { writeAntigravityCredentialStoreToken } =
+      await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
+
+    expect(() =>
+      writeAntigravityCredentialStoreToken({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expiry_timestamp: 1_900_000_000,
+      }),
+    ).toThrow('native keyring update failed');
+
+    expect(mocks.setSecret).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteCredential).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- update native keyring credentials atomically
- add focused regression coverage in `src/tests/unit/antigravity-credential-store-write.test.ts`

## Validation

- `npm test -- src/tests/unit/antigravity-credential-store-write.test.ts` — passed against a temporary merge with current `main`

## Notes

- Native keyring providers were not exercised locally; the focused test uses the repository mock boundary.