### PR TITLE
fix(cloud-account): recover stale auto-switch target state

### DIFF
--- a/src/modules/cloud-account/services/AutoSwitchService.ts
+++ b/src/modules/cloud-account/services/AutoSwitchService.ts
@@ -90,9 +90,17 @@ export class AutoSwitchService {
     // Get current active account for the target
     const accounts = await CloudAccountRepo.getAccounts();
     const activeAccountId = CloudAccountSettingsStore.getActiveAccountIdForTarget(appTarget);
-    const currentAccount = activeAccountId
-      ? accounts.find((a) => a.id === activeAccountId)
-      : accounts.find((a) => a.is_active);
+    const targetAccount = activeAccountId
+      ? accounts.find((account) => account.id === activeAccountId)
+      : undefined;
+
+    if (activeAccountId && !targetAccount) {
+      logger.warn(
+        `AutoSwitch: Active account ${activeAccountId} for target ${appTarget ?? 'default'} no longer exists; falling back to the global active account.`,
+      );
+    }
+
+    const currentAccount = targetAccount ?? accounts.find((account) => account.is_active);
 
     // If no active account, maybe we should pick one?
     if (!currentAccount) return false;

--- a/src/tests/unit/auto-switch.test.ts
+++ b/src/tests/unit/auto-switch.test.ts
@@ -187,4 +187,41 @@ describe('AutoSwitchService', () => {
       id: 'acc-a',
     });
   });
+
+  it('falls back to the global active account when the target account id is stale', async () => {
+    const { CloudAccountRepo } = await import('@/modules/cloud-account/persistence/cloudHandler');
+    const { CloudAccountSettingsStore } =
+      await import('@/modules/cloud-account/persistence/cloud-account-settings-store');
+    const { switchCloudAccount } = await import('@/modules/cloud-account/ipc/handler');
+    const { AutoSwitchService } =
+      await import('@/modules/cloud-account/services/AutoSwitchService');
+
+    vi.mocked(CloudAccountSettingsStore.getSetting).mockImplementation((key: string) => {
+      if (key === 'auto_switch_enabled') return true;
+      if (key === 'auto_switch_models') return {};
+      return undefined;
+    });
+    vi.mocked(CloudAccountSettingsStore.getActiveAccountIdForTarget).mockReturnValue(
+      'deleted-account',
+    );
+    vi.mocked(CloudAccountRepo.getAccounts).mockResolvedValue([
+      createAccount(
+        'global-active',
+        {
+          models: {
+            'gemini-pro': { percentage: 1, resetTime: '' },
+          },
+        },
+        { is_active: true },
+      ),
+      createAccount('healthy-next', {
+        models: {
+          'gemini-pro': { percentage: 90, resetTime: '' },
+        },
+      }),
+    ]);
+
+    await expect(AutoSwitchService.checkAndSwitchIfNeeded('classic')).resolves.toBe(true);
+    expect(switchCloudAccount).toHaveBeenCalledWith('healthy-next', 'classic');
+  });
 });


### PR DESCRIPTION
## Summary

- recover stale auto-switch target state
- add focused regression coverage in `src/tests/unit/auto-switch.test.ts`

## Validation

- `npm test -- src/tests/unit/auto-switch.test.ts` — passed against a temporary merge with current `main`