### PR TITLE
fix(cloud-account): reject expired unrefreshable token injection

### DIFF
--- a/src/modules/cloud-account/persistence/credential-store-injection-adapter.ts
+++ b/src/modules/cloud-account/persistence/credential-store-injection-adapter.ts
@@ -103,6 +103,18 @@ function writeAuthStatusAndCleanup(db: DrizzleExecutor, account: CloudAccount): 
 export class CredentialStoreInjectionAdapter {
   private static versionFailureLogged = false;
 
+  private static assertTokenUsableForInjection(account: CloudAccount): void {
+    const hasRefreshToken =
+      isString(account.token.refresh_token) && account.token.refresh_token.trim().length > 0;
+    const now = Math.floor(Date.now() / 1000);
+
+    if (!hasRefreshToken && account.token.expiry_timestamp <= now) {
+      throw new Error(
+        `Cannot inject expired access token for ${account.email} without a refresh token. Please re-login.`,
+      );
+    }
+  }
+
   private static injectNewFormat(
     orm: BetterSQLite3Database<typeof drizzleSchema>,
     account: CloudAccount,
@@ -398,6 +410,8 @@ export class CredentialStoreInjectionAdapter {
     account: CloudAccount,
     appTarget?: AntigravityAppTarget,
   ): 'credential-store' | 'sqlite' {
+    this.assertTokenUsableForInjection(account);
+
     if (this.shouldInjectTokenIntoCredentialStore(appTarget)) {
       writeAntigravityCredentialStoreToken(account.token);
       return 'credential-store';

--- a/src/tests/unit/credential-store-injection-expiry.test.ts
+++ b/src/tests/unit/credential-store-injection-expiry.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CloudAccount } from '@/modules/cloud-account/types';
+import { CredentialStoreInjectionAdapter } from '@/modules/cloud-account/persistence/credential-store-injection-adapter';
+import { writeAntigravityCredentialStoreToken } from '@/modules/cloud-account/persistence/antigravityCredentialStore';
+
+vi.mock('@/modules/cloud-account/persistence/antigravityCredentialStore', () => ({
+  writeAntigravityCredentialStoreToken: vi.fn(),
+}));
+
+function createAccount(expiryTimestamp: number, refreshToken: string): CloudAccount {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: 'expired-account',
+    provider: 'google',
+    email: 'expired@example.com',
+    name: 'Expired User',
+    avatar_url: '',
+    token: {
+      access_token: 'access-token',
+      refresh_token: refreshToken,
+      expires_in: 3600,
+      expiry_timestamp: expiryTimestamp,
+      token_type: 'Bearer',
+      email: 'expired@example.com',
+    },
+    created_at: now - 7200,
+    last_used: now - 3600,
+    status: 'active',
+    is_active: false,
+  };
+}
+
+describe('CredentialStoreInjectionAdapter token expiry guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('rejects expired access tokens when no refresh token is available', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const account = createAccount(now - 1, '');
+    vi.spyOn(CredentialStoreInjectionAdapter, 'shouldInjectTokenIntoCredentialStore').mockReturnValue(
+      true,
+    );
+
+    expect(() => CredentialStoreInjectionAdapter.injectCloudTokenWithStorageStrategy(account)).toThrow(
+      /expired access token.*without a refresh token/i,
+    );
+    expect(writeAntigravityCredentialStoreToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps valid access tokens usable when no refresh token is available yet', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const account = createAccount(now + 300, '');
+    vi.spyOn(CredentialStoreInjectionAdapter, 'shouldInjectTokenIntoCredentialStore').mockReturnValue(
+      true,
+    );
+
+    expect(CredentialStoreInjectionAdapter.injectCloudTokenWithStorageStrategy(account)).toBe(
+      'credential-store',
+    );
+    expect(writeAntigravityCredentialStoreToken).toHaveBeenCalledWith(account.token);
+  });
+});


### PR DESCRIPTION
## Summary

- reject expired unrefreshable token injection
- add focused regression coverage in `src/tests/unit/credential-store-injection-expiry.test.ts`

## Validation

- `npm test -- src/tests/unit/credential-store-injection-expiry.test.ts` — passed against a temporary merge with current `main`