### PR TITLE
fix(cloud-account): stabilize legacy device history revisions

### DIFF
--- a/src/modules/cloud-account/persistence/cloud-account-device-profile-codec.ts
+++ b/src/modules/cloud-account/persistence/cloud-account-device-profile-codec.ts
@@ -1,5 +1,5 @@
+import { createHash } from 'node:crypto';
 import { isNumber, isPlainObject, isString } from 'lodash-es';
-import { v4 as uuidv4 } from 'uuid';
 import type { DeviceProfile, DeviceProfileVersion } from '@/modules/identity-profile/types';
 
 const DEVICE_PAYLOAD_SCHEMA_VERSION = 1;
@@ -89,6 +89,21 @@ function readVersionedHistoryPayload(value: unknown): unknown {
   return record.history;
 }
 
+function createLegacyDeviceHistoryId(
+  itemRecord: Record<string, unknown>,
+  profile: DeviceProfile,
+  index: number,
+): string {
+  const createdAtCandidate = itemRecord.createdAt;
+  const createdAt =
+    isNumber(createdAtCandidate) && Number.isFinite(createdAtCandidate)
+      ? Math.floor(createdAtCandidate)
+      : null;
+  const label = isString(itemRecord.label) && itemRecord.label.length > 0 ? itemRecord.label : null;
+  const seed = JSON.stringify({ index, createdAt, label, profile });
+  return `legacy-${createHash('sha256').update(seed).digest('hex').slice(0, 32)}`;
+}
+
 export function serializeDeviceProfile(profile: DeviceProfile | undefined): string | null {
   if (!profile) {
     return null;
@@ -114,7 +129,7 @@ export function normalizeDeviceHistory(value: unknown): DeviceProfileVersion[] |
     return undefined;
   }
   const normalized: DeviceProfileVersion[] = [];
-  for (const item of value) {
+  for (const [index, item] of value.entries()) {
     if (!isPlainObject(item)) {
       continue;
     }
@@ -124,7 +139,10 @@ export function normalizeDeviceHistory(value: unknown): DeviceProfileVersion[] |
       continue;
     }
 
-    const id = isString(itemRecord.id) && itemRecord.id.length > 0 ? itemRecord.id : uuidv4();
+    const id =
+      isString(itemRecord.id) && itemRecord.id.length > 0
+        ? itemRecord.id
+        : createLegacyDeviceHistoryId(itemRecord, profile, index);
     const createdAtCandidate = itemRecord.createdAt;
     const createdAt =
       isNumber(createdAtCandidate) && Number.isFinite(createdAtCandidate)

--- a/src/tests/unit/cloud-account-device-profile-codec.test.ts
+++ b/src/tests/unit/cloud-account-device-profile-codec.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { normalizeDeviceHistory } from '@/modules/cloud-account/persistence/cloud-account-device-profile-codec';
+
+const profile = {
+  machineId: 'machine-id',
+  macMachineId: 'mac-machine-id',
+  devDeviceId: 'device-id',
+  sqmId: 'sqm-id',
+};
+
+describe('cloud account device profile codec', () => {
+  it('keeps generated legacy history ids stable across reads', () => {
+    const legacyHistory = [
+      {
+        createdAt: 1_700_000_000,
+        label: 'legacy profile',
+        profile,
+      },
+    ];
+
+    const first = normalizeDeviceHistory(legacyHistory);
+    const second = normalizeDeviceHistory(legacyHistory);
+
+    expect(first?.[0].id).toMatch(/^legacy-[a-f0-9]{32}$/);
+    expect(second?.[0].id).toBe(first?.[0].id);
+  });
+
+  it('does not use the current clock when deriving a legacy history id', () => {
+    const legacyHistory = [{ profile }];
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const first = normalizeDeviceHistory(legacyHistory);
+
+    vi.setSystemTime(new Date('2026-02-01T00:00:00Z'));
+    const second = normalizeDeviceHistory(legacyHistory);
+
+    expect(second?.[0].id).toBe(first?.[0].id);
+    vi.useRealTimers();
+  });
+
+  it('preserves explicit ids and distinguishes duplicate legacy entries', () => {
+    const normalized = normalizeDeviceHistory([
+      { id: 'persisted-id', profile },
+      { profile },
+      { profile },
+    ]);
+
+    expect(normalized?.[0].id).toBe('persisted-id');
+    expect(normalized?.[1].id).not.toBe(normalized?.[2].id);
+  });
+});

--- a/src/tests/unit/cloud-account-device-profile-codec.test.ts
+++ b/src/tests/unit/cloud-account-device-profile-codec.test.ts
@@ -27,15 +27,16 @@ describe('cloud account device profile codec', () => {
 
   it('does not use the current clock when deriving a legacy history id', () => {
     const legacyHistory = [{ profile }];
+    const now = vi.spyOn(Date, 'now');
 
-    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    now.mockReturnValue(1_700_000_000_000);
     const first = normalizeDeviceHistory(legacyHistory);
 
-    vi.setSystemTime(new Date('2026-02-01T00:00:00Z'));
+    now.mockReturnValue(1_800_000_000_000);
     const second = normalizeDeviceHistory(legacyHistory);
 
     expect(second?.[0].id).toBe(first?.[0].id);
-    vi.useRealTimers();
+    now.mockRestore();
   });
 
   it('preserves explicit ids and distinguishes duplicate legacy entries', () => {


### PR DESCRIPTION
## Summary

- stabilize legacy device history revisions
- add focused regression coverage in `src/tests/unit/cloud-account-device-profile-codec.test.ts`

## Validation

- `npm test -- src/tests/unit/cloud-account-device-profile-codec.test.ts` — passed against a temporary merge with current `main`