### PR TITLE
fix(cloud-account): start monitor after enabling auto-switch

### DIFF
--- a/src/modules/cloud-account/services/CloudMonitorService.ts
+++ b/src/modules/cloud-account/services/CloudMonitorService.ts
@@ -117,6 +117,10 @@ export class CloudMonitorService {
   private static lastFocusTime: number = 0;
   private static isPolling: boolean = false;
 
+  private static isAutoSwitchEnabled(): boolean {
+    return CloudAccountSettingsStore.getSetting<boolean>('auto_switch_enabled', false);
+  }
+
   // Helper for testing
   static resetStateForTesting() {
     this.lastFocusTime = 0;
@@ -180,6 +184,10 @@ export class CloudMonitorService {
       clearInterval(this.intervalId);
     }
     this.intervalId = setInterval(() => {
+      if (!this.isAutoSwitchEnabled()) {
+        this.stop();
+        return;
+      }
       this.poll().catch((e) => logger.error('Scheduled poll failed', e));
     }, this.POLL_INTERVAL);
   }
@@ -192,6 +200,10 @@ export class CloudMonitorService {
   }
 
   static async poll() {
+    if (this.isAutoSwitchEnabled() && !this.intervalId) {
+      this.startInterval();
+    }
+
     if (this.isPolling) {
       return; // Extra safety
     }

--- a/src/tests/unit/cloud-monitor-runtime-toggle.test.ts
+++ b/src/tests/unit/cloud-monitor-runtime-toggle.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  autoSwitchEnabled: true,
+  getAccounts: vi.fn(async () => []),
+  getSetting: vi.fn((key: string, defaultValue: unknown) => {
+    return key === 'auto_switch_enabled' ? mocks.autoSwitchEnabled : defaultValue;
+  }),
+  checkAndSwitchIfNeeded: vi.fn(async () => false),
+}));
+
+vi.mock('electron', () => ({
+  Notification: class Notification {
+    show() {}
+  },
+}));
+
+vi.mock('@/modules/cloud-account/persistence/cloudHandler', () => ({
+  CloudAccountRepo: {
+    getAccounts: mocks.getAccounts,
+  },
+}));
+
+vi.mock('@/modules/cloud-account/persistence/cloud-account-settings-store', () => ({
+  CloudAccountSettingsStore: {
+    getSetting: mocks.getSetting,
+  },
+}));
+
+vi.mock('@/modules/cloud-account/services/GoogleAPIService', () => ({
+  GoogleAPIService: {
+    normalizeRefreshedOAuthClientKey: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/cloud-account/services/AutoSwitchService', () => ({
+  AutoSwitchService: {
+    checkAndSwitchIfNeeded: mocks.checkAndSwitchIfNeeded,
+  },
+}));
+
+vi.mock('@/shared/logging/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/cloud-account/utils/account-status', () => ({
+  classifyAccountStatusFromError: vi.fn(() => null),
+}));
+
+import { CloudMonitorService } from '@/modules/cloud-account/services/CloudMonitorService';
+
+describe('CloudMonitorService runtime auto-switch toggles', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.autoSwitchEnabled = true;
+    mocks.getAccounts.mockClear();
+    mocks.getSetting.mockClear();
+    mocks.checkAndSwitchIfNeeded.mockClear();
+    CloudMonitorService.resetStateForTesting();
+  });
+
+  afterEach(() => {
+    CloudMonitorService.resetStateForTesting();
+    vi.useRealTimers();
+  });
+
+  it('starts recurring monitoring when an enabled setting triggers an immediate poll', async () => {
+    await CloudMonitorService.poll();
+
+    expect(mocks.getAccounts).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(mocks.getAccounts).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops the recurring timer after auto-switch is disabled at runtime', async () => {
+    await CloudMonitorService.poll();
+    expect(mocks.getAccounts).toHaveBeenCalledTimes(1);
+
+    mocks.autoSwitchEnabled = false;
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(mocks.getAccounts).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- start monitor after enabling auto-switch
- add focused regression coverage in `src/tests/unit/cloud-monitor-runtime-toggle.test.ts`

## Validation

- `npm test -- src/tests/unit/cloud-monitor-runtime-toggle.test.ts` — passed against a temporary merge with current `main`