### PR TITLE
fix(cloud-account): validate active account setting values

### DIFF
--- a/src/modules/cloud-account/persistence/cloud-account-settings-store.ts
+++ b/src/modules/cloud-account/persistence/cloud-account-settings-store.ts
@@ -52,6 +52,14 @@ export class CloudAccountSettingsStore {
 
   static getActiveAccountIdForTarget(target: AntigravityAppTarget | undefined): string {
     const normalizedTarget = resolveAntigravityAppTarget(target);
-    return this.getSetting(`${ACTIVE_ACCOUNT_SETTING_PREFIX}.${normalizedTarget}`, '');
+    const key = `${ACTIVE_ACCOUNT_SETTING_PREFIX}.${normalizedTarget}`;
+    const value = this.getSetting<unknown>(key, '');
+
+    if (typeof value !== 'string') {
+      logger.warn(`Ignored invalid active account setting ${key}: expected a string`);
+      return '';
+    }
+
+    return value.trim();
   }
 }

--- a/src/tests/unit/cloud-account-settings-store.test.ts
+++ b/src/tests/unit/cloud-account-settings-store.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CloudAccountSettingsStore } from '@/modules/cloud-account/persistence/cloud-account-settings-store';
+
+vi.mock('@/shared/logging/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('CloudAccountSettingsStore.getActiveAccountIdForTarget', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a normalized active account id when the setting is a string', () => {
+    vi.spyOn(CloudAccountSettingsStore, 'getSetting').mockReturnValue('  account-1  ');
+
+    expect(CloudAccountSettingsStore.getActiveAccountIdForTarget('classic')).toBe('account-1');
+  });
+
+  it('fails closed when a valid JSON setting has the wrong type', async () => {
+    const getSetting = vi
+      .spyOn(CloudAccountSettingsStore, 'getSetting')
+      .mockReturnValue({ id: 'account-1' });
+    const { logger } = await import('@/shared/logging/logger');
+
+    expect(CloudAccountSettingsStore.getActiveAccountIdForTarget('ide')).toBe('');
+    expect(getSetting).toHaveBeenCalledWith('active_cloud_account.ide', '');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Ignored invalid active account setting active_cloud_account.ide: expected a string',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- validate active account setting values
- add focused regression coverage in `src/tests/unit/cloud-account-settings-store.test.ts`

## Validation

- `npm test -- src/tests/unit/cloud-account-settings-store.test.ts` — passed against a temporary merge with current `main`