### PR TITLE
fix(cloud-account): validate imported proxy URLs

### DIFF
--- a/src/modules/cloud-account/types.ts
+++ b/src/modules/cloud-account/types.ts
@@ -5,6 +5,7 @@ import {
   type DeviceProfile,
   type DeviceProfileVersion,
 } from '@/modules/identity-profile/types';
+import { isValidProxyUrl } from '@/shared/utils/url';
 
 export interface CloudTokenData {
   access_token: string;
@@ -155,6 +156,10 @@ export const CloudAccountSchema = z.object({
   proxy_url: z.string().optional(),
 });
 
+const ImportedProxyUrlSchema = z.string().refine(isValidProxyUrl, {
+  message: 'Invalid proxy URL',
+});
+
 export const CloudAccountExportSchema = z.object({
   version: z.literal('1.0'),
   exportedAt: z.number(),
@@ -168,7 +173,7 @@ export const CloudAccountExportSchema = z.object({
       quota: CloudQuotaDataSchema.optional(),
       device_profile: z.any().optional(),
       device_history: z.any().optional(),
-      proxy_url: z.string().optional().nullable(),
+      proxy_url: ImportedProxyUrlSchema.optional().nullable(),
       status: z.enum(['active', 'rate_limited', 'expired']).optional(),
       status_reason: z.string().optional(),
     }),

--- a/src/tests/unit/cloud-account-import-schema.test.ts
+++ b/src/tests/unit/cloud-account-import-schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { CloudAccountExportSchema } from '@/modules/cloud-account/types';
+
+function buildExport(proxyUrl?: string | null) {
+  return {
+    version: '1.0' as const,
+    exportedAt: Date.now(),
+    accounts: [
+      {
+        provider: 'google' as const,
+        email: 'user@example.com',
+        proxy_url: proxyUrl,
+      },
+    ],
+  };
+}
+
+describe('CloudAccountExportSchema proxy validation', () => {
+  it.each([
+    'http://127.0.0.1:8080',
+    'https://proxy.example.com:8443',
+    'socks5://127.0.0.1:1080',
+  ])('accepts supported proxy URL %s', (proxyUrl) => {
+    expect(CloudAccountExportSchema.safeParse(buildExport(proxyUrl)).success).toBe(true);
+  });
+
+  it.each(['not-a-url', 'ftp://proxy.example.com:21'])('rejects invalid proxy URL %s', (proxyUrl) => {
+    expect(CloudAccountExportSchema.safeParse(buildExport(proxyUrl)).success).toBe(false);
+  });
+
+  it('continues to allow imports without an account proxy', () => {
+    expect(CloudAccountExportSchema.safeParse(buildExport(undefined)).success).toBe(true);
+    expect(CloudAccountExportSchema.safeParse(buildExport(null)).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- validate imported proxy URLs
- add focused regression coverage in `src/tests/unit/cloud-account-import-schema.test.ts`

## Validation

- `npm test -- src/tests/unit/cloud-account-import-schema.test.ts` — passed against a temporary merge with current `main`
- `npm run type-check` — passed against the same merge