### PR TITLE
fix(proxy): scope rate-limit backoff by model

### DIFF
--- a/src/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service.ts
@@ -257,6 +257,19 @@ export class RateLimitTrackerService {
     return accountId;
   }
 
+  private buildFailureCountKey(
+    accountId: string,
+    reason: RateLimitReason,
+    model?: string,
+  ): string {
+    const isModelScoped =
+      !isEmpty(model?.trim() ?? '') &&
+      (reason === RateLimitReason.QuotaExhausted ||
+        reason === RateLimitReason.RateLimitExceeded ||
+        reason === RateLimitReason.ModelCapacityExhausted);
+    return isModelScoped ? this.buildLockoutKey(accountId, model) : accountId;
+  }
+
   getRemainingWaitSeconds(accountId: string, model?: string): number {
     const now = Date.now();
 
@@ -375,7 +388,7 @@ export class RateLimitTrackerService {
   }
 
   markModelSuccess(accountId: string, model: string): void {
-    this.failureCounts.delete(accountId);
+    this.failureCounts.delete(this.buildLockoutKey(accountId, model));
     this.clearModel(accountId, model);
   }
 
@@ -401,6 +414,7 @@ export class RateLimitTrackerService {
         retryAfter: params.retryAfter,
         body: params.body,
         accountId: params.accountId,
+        model: params.model,
         backoffSteps: params.backoffSteps,
       }),
     );
@@ -493,6 +507,7 @@ export class RateLimitTrackerService {
     retryAfter?: string;
     body?: string;
     accountId: string;
+    model?: string;
     backoffSteps: number[];
   }): number {
     const headerRetryRaw = params.retryAfter?.trim() ?? '';
@@ -518,7 +533,9 @@ export class RateLimitTrackerService {
 
     const failureCount =
       params.reason !== RateLimitReason.ServerError
-        ? this.incrementFailureCount(params.accountId)
+        ? this.incrementFailureCount(
+            this.buildFailureCountKey(params.accountId, params.reason, params.model),
+          )
         : 1;
 
     if (params.reason === RateLimitReason.QuotaExhausted) {
@@ -609,21 +626,21 @@ export class RateLimitTrackerService {
     return null;
   }
 
-  private incrementFailureCount(accountId: string): number {
+  private incrementFailureCount(key: string): number {
     const now = Date.now();
-    const entry = this.failureCounts.get(accountId);
+    const entry = this.failureCounts.get(key);
     if (!entry) {
-      this.failureCounts.set(accountId, { count: 1, lastFailureMs: now });
+      this.failureCounts.set(key, { count: 1, lastFailureMs: now });
       return 1;
     }
 
     if (now - entry.lastFailureMs > FAILURE_COUNT_EXPIRY_MS) {
-      this.failureCounts.set(accountId, { count: 1, lastFailureMs: now });
+      this.failureCounts.set(key, { count: 1, lastFailureMs: now });
       return 1;
     }
 
     const nextCount = entry.count + 1;
-    this.failureCounts.set(accountId, { count: nextCount, lastFailureMs: now });
+    this.failureCounts.set(key, { count: nextCount, lastFailureMs: now });
     return nextCount;
   }
 }

--- a/src/tests/unit/rate-limit-tracker-model-scope.test.ts
+++ b/src/tests/unit/rate-limit-tracker-model-scope.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RateLimitReason,
+  RateLimitTrackerService,
+} from '../../modules/proxy-gateway/server/shared/services/rate-limit-tracker.service';
+
+const backoffSteps = [60, 300, 1800, 7200];
+
+function quotaError(accountId: string, model: string) {
+  return {
+    accountId,
+    status: 429,
+    body: JSON.stringify({
+      error: {
+        details: [{ reason: 'QUOTA_EXHAUSTED' }],
+      },
+    }),
+    model,
+    backoffSteps,
+  };
+}
+
+function capacityError(accountId: string, model: string) {
+  return {
+    accountId,
+    status: 503,
+    body: JSON.stringify({
+      error: {
+        status: 'UNAVAILABLE',
+        details: [{ reason: 'MODEL_CAPACITY_EXHAUSTED' }],
+      },
+    }),
+    model,
+    backoffSteps,
+  };
+}
+
+describe('RateLimitTrackerService model-scoped backoff', () => {
+  it('does not let one model advance another model quota backoff', () => {
+    const tracker = new RateLimitTrackerService();
+
+    const modelAFirst = tracker.parseAndMarkFromError(quotaError('acc-model-scope', 'model-a'));
+    const modelBFirst = tracker.parseAndMarkFromError(quotaError('acc-model-scope', 'model-b'));
+    const modelASecond = tracker.parseAndMarkFromError(quotaError('acc-model-scope', 'model-a'));
+
+    expect(modelAFirst).toMatchObject({
+      reason: RateLimitReason.QuotaExhausted,
+      retryAfterSec: 60,
+    });
+    expect(modelBFirst).toMatchObject({
+      reason: RateLimitReason.QuotaExhausted,
+      retryAfterSec: 60,
+    });
+    expect(modelASecond).toMatchObject({
+      reason: RateLimitReason.QuotaExhausted,
+      retryAfterSec: 300,
+    });
+  });
+
+  it('keeps another model backoff history when one model succeeds', () => {
+    const tracker = new RateLimitTrackerService();
+
+    tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-a'));
+    tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-b'));
+    tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-b'));
+
+    tracker.markModelSuccess('acc-success-scope', 'model-a');
+
+    const modelANext = tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-a'));
+    const modelBNext = tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-b'));
+
+    expect(modelANext?.retryAfterSec).toBe(60);
+    expect(modelBNext?.retryAfterSec).toBe(1800);
+  });
+
+  it('keeps model capacity escalation independent between models', () => {
+    const tracker = new RateLimitTrackerService();
+
+    const modelAFirst = tracker.parseAndMarkFromError(capacityError('acc-capacity-scope', 'model-a'));
+    const modelBFirst = tracker.parseAndMarkFromError(capacityError('acc-capacity-scope', 'model-b'));
+    const modelASecond = tracker.parseAndMarkFromError(capacityError('acc-capacity-scope', 'model-a'));
+
+    expect(modelAFirst?.retryAfterSec).toBe(5);
+    expect(modelBFirst?.retryAfterSec).toBe(5);
+    expect(modelASecond?.retryAfterSec).toBe(10);
+  });
+});

--- a/src/tests/unit/rate-limit-tracker-model-scope.test.ts
+++ b/src/tests/unit/rate-limit-tracker-model-scope.test.ts
@@ -4,7 +4,7 @@ import {
   RateLimitTrackerService,
 } from '../../modules/proxy-gateway/server/shared/services/rate-limit-tracker.service';
 
-const backoffSteps = [60, 300, 1800, 7200];
+const backoffSteps = [10, 20, 40, 80];
 
 function quotaError(accountId: string, model: string) {
   return {
@@ -45,15 +45,15 @@ describe('RateLimitTrackerService model-scoped backoff', () => {
 
     expect(modelAFirst).toMatchObject({
       reason: RateLimitReason.QuotaExhausted,
-      retryAfterSec: 60,
+      retryAfterSec: 10,
     });
     expect(modelBFirst).toMatchObject({
       reason: RateLimitReason.QuotaExhausted,
-      retryAfterSec: 60,
+      retryAfterSec: 10,
     });
     expect(modelASecond).toMatchObject({
       reason: RateLimitReason.QuotaExhausted,
-      retryAfterSec: 300,
+      retryAfterSec: 20,
     });
   });
 
@@ -69,16 +69,22 @@ describe('RateLimitTrackerService model-scoped backoff', () => {
     const modelANext = tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-a'));
     const modelBNext = tracker.parseAndMarkFromError(quotaError('acc-success-scope', 'model-b'));
 
-    expect(modelANext?.retryAfterSec).toBe(60);
-    expect(modelBNext?.retryAfterSec).toBe(1800);
+    expect(modelANext?.retryAfterSec).toBe(10);
+    expect(modelBNext?.retryAfterSec).toBe(40);
   });
 
   it('keeps model capacity escalation independent between models', () => {
     const tracker = new RateLimitTrackerService();
 
-    const modelAFirst = tracker.parseAndMarkFromError(capacityError('acc-capacity-scope', 'model-a'));
-    const modelBFirst = tracker.parseAndMarkFromError(capacityError('acc-capacity-scope', 'model-b'));
-    const modelASecond = tracker.parseAndMarkFromError(capacityError('acc-capacity-scope', 'model-a'));
+    const modelAFirst = tracker.parseAndMarkFromError(
+      capacityError('acc-capacity-scope', 'model-a'),
+    );
+    const modelBFirst = tracker.parseAndMarkFromError(
+      capacityError('acc-capacity-scope', 'model-b'),
+    );
+    const modelASecond = tracker.parseAndMarkFromError(
+      capacityError('acc-capacity-scope', 'model-a'),
+    );
 
     expect(modelAFirst?.retryAfterSec).toBe(5);
     expect(modelBFirst?.retryAfterSec).toBe(5);


### PR DESCRIPTION
## Summary
- track quota, rate-limit, and model-capacity failure counts per account and model
- clear only the recovered model's failure history
- use reachable backoff steps in regression coverage so the test proves model isolation under the 300-second lockout cap

## Validation
- src/tests/unit/rate-limit-tracker-model-scope.test.ts (3 tests)
- TypeScript type-check
- targeted ESLint