### PR TITLE
fix(proxy): honor structured retry delays

### DIFF
--- a/src/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy.ts
+++ b/src/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy.ts
@@ -2,6 +2,7 @@ import { isEmpty, isString } from 'lodash-es';
 import {
   hasExplicitQuotaExhaustedSignal,
   hasGenericResourceExhaustedSignal,
+  parseRetryDelayMilliseconds,
   RateLimitReason,
   RateLimitTrackerService,
 } from '../../../shared/services/rate-limit-tracker.service';
@@ -106,7 +107,7 @@ export class AccountLeaseLimitPolicy {
     const normalizedModel = normalizeModelId(params.model);
     const hasExplicitRetryWindow =
       Boolean(isString(params.retryAfter) && !isEmpty(params.retryAfter.trim())) ||
-      Boolean(params.body && params.body.includes('quotaResetDelay'));
+      parseRetryDelayMilliseconds(params.body) !== null;
 
     if (!hasExplicitRetryWindow && (params.status ?? 0) === 429) {
       const reason = this.detectRateLimitReasonFromBody(params.body);

--- a/src/tests/unit/account-lease-structured-retry-delay.test.ts
+++ b/src/tests/unit/account-lease-structured-retry-delay.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AccountLeaseLimitPolicy } from '@/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy';
+
+describe('AccountLeaseLimitPolicy structured retry delays', () => {
+  it('honors an upstream retryDelay without replacing it with a quota refresh decision', async () => {
+    const refreshRealtimeQuotaAndReconcileLimit = vi.fn(async () => 'recovered' as const);
+    const setPreciseLockoutFromCachedQuota = vi.fn(() => false);
+    const logger = { warn: vi.fn() };
+    const policy = new AccountLeaseLimitPolicy({
+      rateLimitCooldownMs: 60_000,
+      forbiddenCooldownMs: 60_000,
+      resolveAccountId: (value) => value,
+      getCircuitBreakerBackoffSteps: () => [60, 300, 1800],
+      refreshRealtimeQuotaAndReconcileLimit,
+      setPreciseLockoutFromCachedQuota,
+      logger,
+    });
+
+    await policy.markFromUpstreamError({
+      accountIdOrEmail: 'acc-1',
+      status: 429,
+      model: 'models/gemini-3.1-pro',
+      body: JSON.stringify({
+        error: {
+          status: 'RESOURCE_EXHAUSTED',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+              retryDelay: '12s',
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(refreshRealtimeQuotaAndReconcileLimit).not.toHaveBeenCalled();
+    expect(setPreciseLockoutFromCachedQuota).not.toHaveBeenCalled();
+    expect(policy.isRateLimited('acc-1', 'gemini-3.1-pro')).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Recorded upstream limit for account acc-1'),
+    );
+  });
+});

--- a/src/tests/unit/account-lease-structured-retry-delay.test.ts
+++ b/src/tests/unit/account-lease-structured-retry-delay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AccountLeaseLimitPolicy } from '@/modules/proxy-gateway/server/modules/account-lease/policies/account-lease-limit.policy';
+import { RateLimitTrackerService } from '@/modules/proxy-gateway/server/shared/services/rate-limit-tracker.service';
 
 describe('AccountLeaseLimitPolicy structured retry delays', () => {
   it('honors an upstream retryDelay without replacing it with a quota refresh decision', async () => {
@@ -14,6 +15,7 @@ describe('AccountLeaseLimitPolicy structured retry delays', () => {
       refreshRealtimeQuotaAndReconcileLimit,
       setPreciseLockoutFromCachedQuota,
       logger,
+      rateLimitTracker: new RateLimitTrackerService(),
     });
 
     await policy.markFromUpstreamError({
@@ -37,7 +39,7 @@ describe('AccountLeaseLimitPolicy structured retry delays', () => {
     expect(setPreciseLockoutFromCachedQuota).not.toHaveBeenCalled();
     expect(policy.isRateLimited('acc-1', 'gemini-3.1-pro')).toBe(true);
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Recorded upstream limit for account acc-1'),
+      expect.stringContaining('Recorded upstream limit for account acc-1: reason=rate_limit_exceeded, wait=14s'),
     );
   });
 });


### PR DESCRIPTION
## Summary
- preserve an upstream structured RetryInfo retryDelay instead of replacing it with quota-refresh handling
- update the policy test for the shared RateLimitTrackerService dependency
- assert the actual 14-second lockout after the 12-second upstream delay and 1.5-second safety buffer

## Validation
- account-lease structured retry-delay and limit-policy tests (7 tests)
- TypeScript type-check
- targeted ESLint