### PR TITLE
fix(proxy): serialize gateway lifecycle operations

### DIFF
--- a/src/modules/proxy-gateway/ipc/handlers.ts
+++ b/src/modules/proxy-gateway/ipc/handlers.ts
@@ -13,41 +13,54 @@ import { v4 as uuidv4 } from 'uuid';
 import { logger } from '@/shared/logging/logger';
 import { explicitContextCacheManager } from '../server/modules/gemini/explicit-context-cache.store';
 
+let gatewayLifecycleQueue: Promise<void> = Promise.resolve();
+
+function enqueueGatewayLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+  const result = gatewayLifecycleQueue.then(operation);
+  gatewayLifecycleQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 /**
  * Start the gateway server (NestJS)
  */
-export const startGateway = async (port: number): Promise<NestServerStartResult> => {
-  try {
-    // Stop if already running
-    await stopNestServer();
+export const startGateway = (port: number): Promise<NestServerStartResult> =>
+  enqueueGatewayLifecycle(async () => {
+    try {
+      // Stop if already running
+      await stopNestServer();
 
-    // Load full config and start NestJS server
-    const config = ConfigManager.loadConfig();
-    const proxyConfig = { ...config.proxy, port };
+      // Load full config and start NestJS server
+      const config = ConfigManager.loadConfig();
+      const proxyConfig = { ...config.proxy, port };
 
-    return await bootstrapNestServer(proxyConfig);
-  } catch (e) {
-    logger.error('Failed to start gateway:', e);
-    return {
-      success: false,
-      reason: 'unknown',
-      port,
-      message: e instanceof Error ? e.message : 'Failed to start gateway',
-    };
-  }
-};
+      return await bootstrapNestServer(proxyConfig);
+    } catch (e) {
+      logger.error('Failed to start gateway:', e);
+      return {
+        success: false,
+        reason: 'unknown',
+        port,
+        message: e instanceof Error ? e.message : 'Failed to start gateway',
+      };
+    }
+  });
 
 /**
  * Stop the gateway server (NestJS)
  */
-export const stopGateway = async (): Promise<boolean> => {
-  try {
-    return await stopNestServer();
-  } catch (e) {
-    logger.error('Failed to stop gateway:', e);
-    return false;
-  }
-};
+export const stopGateway = (): Promise<boolean> =>
+  enqueueGatewayLifecycle(async () => {
+    try {
+      return await stopNestServer();
+    } catch (e) {
+      logger.error('Failed to stop gateway:', e);
+      return false;
+    }
+  });
 
 /**
  * Get gateway status (NestJS)

--- a/src/tests/unit/gateway-lifecycle.test.ts
+++ b/src/tests/unit/gateway-lifecycle.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.st
   },
 }));
 
-import { startGateway } from '@/modules/proxy-gateway/ipc/handlers';
+import { startGateway, stopGateway } from '@/modules/proxy-gateway/ipc/handlers';
 
 describe('gateway lifecycle serialization', () => {
   beforeEach(() => {
@@ -78,5 +78,43 @@ describe('gateway lifecycle serialization', () => {
     expect(mockBootstrapNestServer).toHaveBeenCalledTimes(2);
     expect(mockBootstrapNestServer.mock.calls[0]?.[0]).toMatchObject({ port: 8045 });
     expect(mockBootstrapNestServer.mock.calls[1]?.[0]).toMatchObject({ port: 8123 });
+  });
+
+  it('queues a stop until the active start has completed', async () => {
+    let releaseBootstrap!: (value: { success: true; port: number; base_url: string }) => void;
+    const firstBootstrap = new Promise<{ success: true; port: number; base_url: string }>((resolve) => {
+      releaseBootstrap = resolve;
+    });
+    mockStopNestServer.mockResolvedValue(true);
+    mockBootstrapNestServer.mockReturnValueOnce(firstBootstrap);
+
+    const start = startGateway(8045);
+    await vi.waitFor(() => {
+      expect(mockBootstrapNestServer).toHaveBeenCalledTimes(1);
+    });
+
+    const stop = stopGateway();
+    expect(mockStopNestServer).toHaveBeenCalledTimes(1);
+
+    releaseBootstrap({ success: true, port: 8045, base_url: 'http://localhost:8045' });
+
+    await expect(start).resolves.toMatchObject({ success: true, port: 8045 });
+    await expect(stop).resolves.toBe(true);
+    expect(mockStopNestServer).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the queue after a failed start', async () => {
+    mockStopNestServer.mockResolvedValue(true);
+    mockBootstrapNestServer
+      .mockRejectedValueOnce(new Error('bind failed'))
+      .mockResolvedValueOnce({ success: true, port: 8123, base_url: 'http://localhost:8123' });
+
+    const failedStart = startGateway(8045);
+    const succeedingStart = startGateway(8123);
+
+    await expect(failedStart).resolves.toMatchObject({ success: false, port: 8045 });
+    await expect(succeedingStart).resolves.toMatchObject({ success: true, port: 8123 });
+    expect(mockStopNestServer).toHaveBeenCalledTimes(2);
+    expect(mockBootstrapNestServer).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/tests/unit/gateway-lifecycle.test.ts
+++ b/src/tests/unit/gateway-lifecycle.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockBootstrapNestServer, mockLoadConfig, mockStopNestServer } = vi.hoisted(() => ({
+  mockBootstrapNestServer: vi.fn(),
+  mockLoadConfig: vi.fn(() => ({
+    proxy: {
+      api_key: '',
+      port: 8045,
+    },
+  })),
+  mockStopNestServer: vi.fn(),
+}));
+
+vi.mock('@/server/main', () => ({
+  bootstrapNestServer: mockBootstrapNestServer,
+  getNestServerStatus: vi.fn(),
+  stopNestServer: mockStopNestServer,
+}));
+
+vi.mock('@/modules/config/ipc/manager', () => ({
+  ConfigManager: {
+    loadConfig: mockLoadConfig,
+    saveConfig: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/logging/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.store', () => ({
+  explicitContextCacheManager: {
+    getStats: vi.fn(() => ({})),
+  },
+}));
+
+import { startGateway } from '@/modules/proxy-gateway/ipc/handlers';
+
+describe('gateway lifecycle serialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadConfig.mockReturnValue({
+      proxy: {
+        api_key: '',
+        port: 8045,
+      },
+    });
+    mockBootstrapNestServer.mockImplementation(async (config: { port: number }) => ({
+      success: true,
+      port: config.port,
+      base_url: `http://localhost:${config.port}`,
+    }));
+  });
+
+  it('serializes concurrent gateway starts across stop and bootstrap', async () => {
+    let releaseFirstStop!: (value: boolean) => void;
+    const firstStop = new Promise<boolean>((resolve) => {
+      releaseFirstStop = resolve;
+    });
+    mockStopNestServer.mockReturnValueOnce(firstStop).mockResolvedValue(true);
+
+    const firstStart = startGateway(8045);
+    const secondStart = startGateway(8123);
+
+    await vi.waitFor(() => {
+      expect(mockStopNestServer).toHaveBeenCalledTimes(1);
+    });
+    expect(mockBootstrapNestServer).not.toHaveBeenCalled();
+
+    releaseFirstStop(true);
+
+    await expect(firstStart).resolves.toMatchObject({ success: true, port: 8045 });
+    await expect(secondStart).resolves.toMatchObject({ success: true, port: 8123 });
+
+    expect(mockStopNestServer).toHaveBeenCalledTimes(2);
+    expect(mockBootstrapNestServer).toHaveBeenCalledTimes(2);
+    expect(mockBootstrapNestServer.mock.calls[0]?.[0]).toMatchObject({ port: 8045 });
+    expect(mockBootstrapNestServer.mock.calls[1]?.[0]).toMatchObject({ port: 8123 });
+  });
+});


### PR DESCRIPTION
## Summary
- serialize gateway start and stop operations through one failure-tolerant queue
- prevent overlapping stop, configuration, and bootstrap work
- cover concurrent starts, start/stop ordering, and recovery after a failed start

## Validation
- src/tests/unit/gateway-lifecycle.test.ts (3 tests)
- TypeScript type-check
- targeted ESLint