### PR TITLE
fix(security): hide production ORPC backend stacks

### DIFF
--- a/src/ipc/router.ts
+++ b/src/ipc/router.ts
@@ -38,6 +38,10 @@ function stringifyUnknownError(error: unknown): string {
   }
 }
 
+function getPublicBackendStack(error: Error): string | undefined {
+  return process.env.NODE_ENV === 'development' ? error.stack : undefined;
+}
+
 function createBackendErrorDetails(error: unknown, requestPath: string): BackendErrorDetails {
   const message = stringifyUnknownError(error);
 
@@ -47,7 +51,7 @@ function createBackendErrorDetails(error: unknown, requestPath: string): Backend
       backendStatus: error.status,
       backendName: error.name,
       backendMessage: message,
-      backendStack: error.stack,
+      backendStack: getPublicBackendStack(error),
       requestPath,
     };
   }
@@ -56,7 +60,7 @@ function createBackendErrorDetails(error: unknown, requestPath: string): Backend
     return {
       backendName: error.name,
       backendMessage: message,
-      backendStack: error.stack,
+      backendStack: getPublicBackendStack(error),
       requestPath,
     };
   }

--- a/src/ipc/router.ts
+++ b/src/ipc/router.ts
@@ -42,6 +42,11 @@ function getPublicBackendStack(error: Error): string | undefined {
   return process.env.NODE_ENV === 'development' ? error.stack : undefined;
 }
 
+function getPublicBackendStackDetails(error: Error): Pick<BackendErrorDetails, 'backendStack'> {
+  const backendStack = getPublicBackendStack(error);
+  return backendStack ? { backendStack } : {};
+}
+
 function createBackendErrorDetails(error: unknown, requestPath: string): BackendErrorDetails {
   const message = stringifyUnknownError(error);
 
@@ -51,7 +56,7 @@ function createBackendErrorDetails(error: unknown, requestPath: string): Backend
       backendStatus: error.status,
       backendName: error.name,
       backendMessage: message,
-      backendStack: getPublicBackendStack(error),
+      ...getPublicBackendStackDetails(error),
       requestPath,
     };
   }
@@ -60,7 +65,7 @@ function createBackendErrorDetails(error: unknown, requestPath: string): Backend
     return {
       backendName: error.name,
       backendMessage: message,
-      backendStack: getPublicBackendStack(error),
+      ...getPublicBackendStackDetails(error),
       requestPath,
     };
   }

--- a/src/tests/unit/orpc-error-security.test.ts
+++ b/src/tests/unit/orpc-error-security.test.ts
@@ -1,13 +1,35 @@
-import { readFileSync } from 'fs';
-import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { toPublicORPCError } from '@/ipc/router';
 
 describe('ORPC public error details', () => {
-  it('does not expose backend stacks outside development', () => {
-    const routerSource = readFileSync(path.join(process.cwd(), 'src/ipc/router.ts'), 'utf-8');
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
-    expect(routerSource).toContain("process.env.NODE_ENV === 'development'");
-    expect(routerSource).toContain('backendStack: getPublicBackendStack(error)');
-    expect(routerSource).not.toContain('backendStack: error.stack');
+  it('does not expose backend stacks in production ORPC errors', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const error = new Error('database unavailable');
+    error.stack = 'Error: database unavailable\n    at C:\\private\\server.ts:1:1';
+
+    const publicError = toPublicORPCError(error, 'cloud.list');
+
+    expect(publicError.data).toMatchObject({
+      backendName: 'Error',
+      backendMessage: 'database unavailable',
+      requestPath: 'cloud.list',
+    });
+    expect(publicError.data).not.toHaveProperty('backendStack');
+  });
+
+  it('keeps backend stacks available in development ORPC errors', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const error = new Error('database unavailable');
+    error.stack = 'Error: database unavailable\n    at C:\\private\\server.ts:1:1';
+
+    const publicError = toPublicORPCError(error, 'cloud.list');
+
+    expect(publicError.data).toMatchObject({
+      backendStack: error.stack,
+    });
   });
 });

--- a/src/tests/unit/orpc-error-security.test.ts
+++ b/src/tests/unit/orpc-error-security.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+describe('ORPC public error details', () => {
+  it('does not expose backend stacks outside development', () => {
+    const routerSource = readFileSync(path.join(process.cwd(), 'src/ipc/router.ts'), 'utf-8');
+
+    expect(routerSource).toContain("process.env.NODE_ENV === 'development'");
+    expect(routerSource).toContain('backendStack: getPublicBackendStack(error)');
+    expect(routerSource).not.toContain('backendStack: error.stack');
+  });
+});


### PR DESCRIPTION
## Summary
- omit backend stack traces from public ORPC error data outside development
- retain development diagnostics without serializing an undefined stack field in production
- replace source-text inspection with direct error-boundary coverage for production and development

## Validation
- src/tests/unit/orpc-error-security.test.ts (2 tests)
- TypeScript type-check
- targeted ESLint