### PR TITLE
fix(security): deny unexpected renderer capabilities

### DIFF
--- a/src/ipc/context.ts
+++ b/src/ipc/context.ts
@@ -1,11 +1,13 @@
 import { os } from '@orpc/server';
 import { BrowserWindow } from 'electron';
+import { installRendererNavigationPolicy } from '@/modules/app-shell/utils/rendererNavigationPolicy';
 import { installRendererRecovery } from '@/modules/app-shell/utils/rendererRecovery';
 
 class IPCContext {
   public mainWindow: BrowserWindow | undefined;
 
   public setMainWindow(window: BrowserWindow) {
+    installRendererNavigationPolicy(window);
     installRendererRecovery(window);
     this.mainWindow = window;
   }

--- a/src/ipc/context.ts
+++ b/src/ipc/context.ts
@@ -1,6 +1,7 @@
 import { os } from '@orpc/server';
 import { BrowserWindow } from 'electron';
 import { installRendererNavigationPolicy } from '@/modules/app-shell/utils/rendererNavigationPolicy';
+import { installRendererPermissionPolicy } from '@/modules/app-shell/utils/rendererPermissionPolicy';
 import { installRendererRecovery } from '@/modules/app-shell/utils/rendererRecovery';
 
 class IPCContext {
@@ -8,6 +9,7 @@ class IPCContext {
 
   public setMainWindow(window: BrowserWindow) {
     installRendererNavigationPolicy(window);
+    installRendererPermissionPolicy(window);
     installRendererRecovery(window);
     this.mainWindow = window;
   }

--- a/src/modules/app-shell/utils/rendererNavigationPolicy.ts
+++ b/src/modules/app-shell/utils/rendererNavigationPolicy.ts
@@ -1,0 +1,25 @@
+import type { BrowserWindow } from 'electron';
+
+const configuredWebContents = new WeakSet<BrowserWindow['webContents']>();
+
+export function installRendererNavigationPolicy(window: BrowserWindow): void {
+  const { webContents } = window;
+  if (configuredWebContents.has(webContents)) {
+    return;
+  }
+  configuredWebContents.add(webContents);
+
+  webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+
+  webContents.on('will-navigate', (event) => {
+    event.preventDefault();
+  });
+
+  webContents.on('will-frame-navigate', (event) => {
+    event.preventDefault();
+  });
+
+  webContents.on('will-attach-webview', (event) => {
+    event.preventDefault();
+  });
+}

--- a/src/modules/app-shell/utils/rendererPermissionPolicy.ts
+++ b/src/modules/app-shell/utils/rendererPermissionPolicy.ts
@@ -1,0 +1,18 @@
+import type { BrowserWindow, Session } from 'electron';
+
+const configuredSessions = new WeakSet<Session>();
+
+export function installRendererPermissionPolicy(window: BrowserWindow): void {
+  const rendererSession = window.webContents.session;
+
+  if (configuredSessions.has(rendererSession)) {
+    return;
+  }
+
+  rendererSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    callback(false);
+  });
+  rendererSession.setPermissionCheckHandler(() => false);
+
+  configuredSessions.add(rendererSession);
+}

--- a/src/tests/unit/renderer-navigation-policy.test.ts
+++ b/src/tests/unit/renderer-navigation-policy.test.ts
@@ -1,0 +1,40 @@
+import type { BrowserWindow } from 'electron';
+import { describe, expect, it, vi } from 'vitest';
+
+import { installRendererNavigationPolicy } from '@/modules/app-shell/utils/rendererNavigationPolicy';
+
+describe('renderer navigation policy', () => {
+  it('denies windows, navigations, frame navigations, and webview attachment', () => {
+    const handlers = new Map<string, (...args: any[]) => void>();
+    const setWindowOpenHandler = vi.fn();
+    const on = vi.fn((event: string, handler: (...args: any[]) => void) => {
+      handlers.set(event, handler);
+    });
+    const webContents = { setWindowOpenHandler, on };
+    const window = { webContents } as unknown as BrowserWindow;
+
+    installRendererNavigationPolicy(window);
+
+    const openHandler = setWindowOpenHandler.mock.calls[0]?.[0];
+    expect(openHandler()).toEqual({ action: 'deny' });
+
+    for (const eventName of ['will-navigate', 'will-frame-navigate', 'will-attach-webview']) {
+      const preventDefault = vi.fn();
+      handlers.get(eventName)?.({ preventDefault });
+      expect(preventDefault).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('installs the policy only once for the same webContents', () => {
+    const setWindowOpenHandler = vi.fn();
+    const on = vi.fn();
+    const webContents = { setWindowOpenHandler, on };
+    const window = { webContents } as unknown as BrowserWindow;
+
+    installRendererNavigationPolicy(window);
+    installRendererNavigationPolicy(window);
+
+    expect(setWindowOpenHandler).toHaveBeenCalledOnce();
+    expect(on).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/tests/unit/renderer-permission-policy.test.ts
+++ b/src/tests/unit/renderer-permission-policy.test.ts
@@ -1,0 +1,51 @@
+import type { BrowserWindow, Session } from 'electron';
+import { describe, expect, it, vi } from 'vitest';
+import { installRendererPermissionPolicy } from '@/modules/app-shell/utils/rendererPermissionPolicy';
+
+describe('renderer permission policy', () => {
+  it('denies unexpected permission requests and checks', () => {
+    const setPermissionRequestHandler = vi.fn();
+    const setPermissionCheckHandler = vi.fn();
+    const rendererSession = {
+      setPermissionRequestHandler,
+      setPermissionCheckHandler,
+    } as unknown as Session;
+    const window = {
+      webContents: { session: rendererSession },
+    } as unknown as BrowserWindow;
+
+    installRendererPermissionPolicy(window);
+
+    expect(setPermissionRequestHandler).toHaveBeenCalledTimes(1);
+    expect(setPermissionCheckHandler).toHaveBeenCalledTimes(1);
+
+    const requestHandler = setPermissionRequestHandler.mock.calls[0][0];
+    const callback = vi.fn();
+    requestHandler(undefined, 'media', callback);
+    expect(callback).toHaveBeenCalledWith(false);
+
+    const checkHandler = setPermissionCheckHandler.mock.calls[0][0];
+    expect(checkHandler()).toBe(false);
+  });
+
+  it('configures a shared Electron session only once', () => {
+    const setPermissionRequestHandler = vi.fn();
+    const setPermissionCheckHandler = vi.fn();
+    const rendererSession = {
+      setPermissionRequestHandler,
+      setPermissionCheckHandler,
+    } as unknown as Session;
+    const firstWindow = {
+      webContents: { session: rendererSession },
+    } as unknown as BrowserWindow;
+    const secondWindow = {
+      webContents: { session: rendererSession },
+    } as unknown as BrowserWindow;
+
+    installRendererPermissionPolicy(firstWindow);
+    installRendererPermissionPolicy(secondWindow);
+
+    expect(setPermissionRequestHandler).toHaveBeenCalledTimes(1);
+    expect(setPermissionCheckHandler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- deny renderer-created windows, document and frame navigations, and webview attachment
- deny all unexpected renderer permission checks and requests
- install both policies once at the shared main-window lifecycle boundary

## Validation
- renderer navigation and permission policy tests (4 tests)
- TypeScript type-check
- targeted ESLint