### PR TITLE
fix(security): migrate legacy encrypted account data

### DIFF
--- a/src/shared/security/security.ts
+++ b/src/shared/security/security.ts
@@ -140,10 +140,15 @@ export async function decryptWithMigration(
     try {
       const value = decryptParsedPayloadWithKey(candidate.key, payload);
       const usedFallback = candidate.key.equals(primary.key) ? undefined : candidate.source;
+      const reencrypted = usedFallback
+        ? encryptWithKey(primary.key, value)
+        : payload.isVersioned
+          ? undefined
+          : `${ENCRYPTED_PAYLOAD_VERSION_PREFIX}${text}`;
 
       return {
         value,
-        reencrypted: payload.isVersioned ? undefined : `${ENCRYPTED_PAYLOAD_VERSION_PREFIX}${text}`,
+        reencrypted,
         usedFallback,
       };
     } catch (error) {

--- a/src/shared/security/security.ts
+++ b/src/shared/security/security.ts
@@ -117,8 +117,17 @@ export async function encrypt(text: string): Promise<string> {
 export async function decryptWithMigration(
   text: string,
 ): Promise<{ value: string; reencrypted?: string; usedFallback?: KeySource }> {
-  if (text.startsWith('{') || text.startsWith('[')) {
-    return { value: text };
+  const trimmedText = text.trimStart();
+  if (trimmedText.startsWith('{') || trimmedText.startsWith('[')) {
+    if (trimmedText === text) {
+      return { value: text };
+    }
+
+    const { key } = getMasterKeyManager().getPrimaryKey();
+    return {
+      value: text,
+      reencrypted: encryptWithKey(key, text),
+    };
   }
 
   const payload = parseEncryptedPayload(text);

--- a/src/tests/unit/security-fallback-key-migration.test.ts
+++ b/src/tests/unit/security-fallback-key-migration.test.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  decryptParsedPayloadWithKey,
+  encryptWithKey,
+  parseEncryptedPayload,
+} from '@/shared/security/crypto';
+
+const electronState = vi.hoisted(() => ({
+  userDataPath: '',
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: () => electronState.userDataPath,
+    getPath: () => electronState.userDataPath,
+  },
+  safeStorage: {
+    decryptString: (value: Buffer) => value.toString('utf8'),
+    encryptString: (value: string) => Buffer.from(value, 'utf8'),
+    isEncryptionAvailable: () => true,
+  },
+}));
+
+vi.mock('keytar', () => ({
+  default: {
+    findCredentials: vi.fn().mockResolvedValue([]),
+    getPassword: vi.fn().mockResolvedValue(null),
+    setPassword: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('fallback master-key migration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agm-key-migration-'));
+    electronState.userDataPath = tempDir;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('re-encrypts versioned fallback payloads with the primary key', async () => {
+    const primaryKey = Buffer.alloc(32, 0x11);
+    const fallbackKey = Buffer.alloc(32, 0x22);
+    const primaryPayload = encryptWithKey(primaryKey, JSON.stringify({ account: 'primary' }));
+    const fallbackPayload = encryptWithKey(fallbackKey, JSON.stringify({ account: 'fallback' }));
+
+    await fs.writeFile(path.join(tempDir, 'master-key.v2.safe'), primaryKey.toString('hex'));
+    await fs.writeFile(path.join(tempDir, 'master-key.v2.file'), fallbackKey.toString('hex'));
+
+    const security = await import('@/shared/security/security');
+    await security.initializeMasterKey({
+      encryptedSamples: [primaryPayload, fallbackPayload],
+      storedAccountCount: 2,
+    });
+
+    const result = await security.decryptWithMigration(fallbackPayload);
+
+    expect(result.value).toBe(JSON.stringify({ account: 'fallback' }));
+    expect(result.usedFallback).toBe('file');
+    expect(result.reencrypted).toBeDefined();
+    expect(result.reencrypted).not.toBe(fallbackPayload);
+
+    const migratedPayload = parseEncryptedPayload(result.reencrypted!);
+    expect(migratedPayload).not.toBeNull();
+    expect(decryptParsedPayloadWithKey(primaryKey, migratedPayload!)).toBe(result.value);
+    expect(() => decryptParsedPayloadWithKey(fallbackKey, migratedPayload!)).toThrow();
+  });
+
+  it('does not rewrite an already versioned payload encrypted by the primary key', async () => {
+    const primaryKey = Buffer.alloc(32, 0x33);
+    const primaryPayload = encryptWithKey(primaryKey, JSON.stringify({ account: 'primary' }));
+
+    await fs.writeFile(path.join(tempDir, 'master-key.v2.safe'), primaryKey.toString('hex'));
+
+    const security = await import('@/shared/security/security');
+    await security.initializeMasterKey({
+      encryptedSamples: [primaryPayload],
+      storedAccountCount: 1,
+    });
+
+    const result = await security.decryptWithMigration(primaryPayload);
+
+    expect(result.usedFallback).toBeUndefined();
+    expect(result.reencrypted).toBeUndefined();
+  });
+});

--- a/src/tests/unit/security-migration.test.ts
+++ b/src/tests/unit/security-migration.test.ts
@@ -170,7 +170,7 @@ describe('decryptWithMigration', () => {
     expect(result.reencrypted).toBe(`agm_enc_v1:${ciphertext}`);
   });
 
-  it('uses a recovered historical key without changing the DEK', async () => {
+  it('migrates a recovered historical key payload to the primary DEK', async () => {
     const plaintext = '{"token":"legacy"}';
     const ciphertext = encryptWithKey(Buffer.from(fallbackHex, 'hex'), plaintext);
 
@@ -178,11 +178,12 @@ describe('decryptWithMigration', () => {
 
     expect(result.value).toBe(plaintext);
     expect(result.usedFallback).toBe('keytar');
-    expect(result.reencrypted).toBe(`agm_enc_v1:${ciphertext}`);
+    expect(result.reencrypted).toMatch(/^agm_enc_v1:/);
+    expect(result.reencrypted).not.toBe(`agm_enc_v1:${ciphertext}`);
     if (result.reencrypted) {
       const migrated = await decryptWithMigration(result.reencrypted);
       expect(migrated.value).toBe(plaintext);
-      expect(migrated.usedFallback).toBe('keytar');
+      expect(migrated.usedFallback).toBeUndefined();
     }
   });
 
@@ -233,7 +234,7 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expiry_timestamp: 1_700_000_000,
   };
 
-  it('writes go-keyring-base64 payload on macOS', async () => {
+  it('writes the macOS keychain payload through stdin', async () => {
     setPlatform('darwin');
 
     const { writeAntigravityCredentialStoreToken } =
@@ -243,8 +244,12 @@ describe('writeAntigravityCredentialStoreToken', () => {
 
     expect(childProcessMock.execFileSync).toHaveBeenLastCalledWith(
       'security',
-      expect.arrayContaining(['-w', expect.stringMatching(/^go-keyring-base64:/)]),
-      { stdio: 'ignore' },
+      ['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-A', '-U', '-w'],
+      expect.objectContaining({
+        input: expect.stringMatching(/^go-keyring-base64:/),
+        encoding: 'utf-8',
+        stdio: ['pipe', 'ignore', 'ignore'],
+      }),
     );
   });
 

--- a/src/tests/unit/security-whitespace-plaintext-migration.test.ts
+++ b/src/tests/unit/security-whitespace-plaintext-migration.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs/promises';
+import { safeStorage } from 'electron';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: vi.fn(() => true),
+    decryptString: vi.fn(),
+    encryptString: vi.fn((value: string) => Buffer.from(value, 'utf8')),
+  },
+  app: {
+    getPath: vi.fn(() => 'C:\\test'),
+    getAppPath: vi.fn(() => 'C:\\test\\app.asar'),
+  },
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}));
+
+vi.mock('keytar', () => ({
+  default: {
+    findCredentials: vi.fn(async () => []),
+    getPassword: vi.fn(async () => null),
+    setPassword: vi.fn(async () => undefined),
+  },
+}));
+
+const fsMock = vi.mocked(fs, { deep: true });
+const safeStorageMock = vi.mocked(safeStorage, { deep: true });
+
+describe('whitespace-prefixed plaintext account migration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true);
+    safeStorageMock.encryptString.mockImplementation((value: string) => Buffer.from(value, 'utf8'));
+    fsMock.readFile.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    fsMock.writeFile.mockResolvedValue(undefined);
+  });
+
+  it('returns an encrypted replacement for JSON with leading whitespace', async () => {
+    const security = await import('@/shared/security/security');
+    await security.initializeMasterKey({ encryptedSamples: [], storedAccountCount: 0 });
+
+    const plaintext = ' \n\t{"access_token":"legacy-token"}';
+    const result = await security.decryptWithMigration(plaintext);
+
+    expect(result.value).toBe(plaintext);
+    expect(result.reencrypted).toMatch(/^agm_enc_v1:/);
+
+    const migrated = await security.decryptWithMigration(result.reencrypted!);
+    expect(migrated.value).toBe(plaintext);
+    expect(migrated.reencrypted).toBeUndefined();
+  });
+
+  it('keeps canonical plaintext JSON on the existing startup migration path', async () => {
+    const security = await import('@/shared/security/security');
+    await security.initializeMasterKey({ encryptedSamples: [], storedAccountCount: 0 });
+
+    const result = await security.decryptWithMigration('{"access_token":"legacy-token"}');
+
+    expect(result.value).toBe('{"access_token":"legacy-token"}');
+    expect(result.reencrypted).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- encrypt whitespace-prefixed legacy JSON account data with the primary key
- re-encrypt fallback-key payloads with the primary key after a successful read
- align existing migration and macOS credential-store regression coverage with current security behavior

## Validation
- security migration and cloud-handler migration tests (24 tests)
- TypeScript type-check
- targeted ESLint