### PR TITLE
fix(identity-profile): fail closed on profile apply errors

### DIFF
--- a/src/modules/antigravity-runtime/switch/switchFlow.ts
+++ b/src/modules/antigravity-runtime/switch/switchFlow.ts
@@ -170,8 +170,12 @@ export async function executeSwitchFlow(options: SwitchFlowOptions): Promise<voi
           await trace.phase('performSwitchMs', performSwitch);
           if (applyFingerprint) {
             stage = 'apply';
+            if (!targetProfile) {
+              stage = 'missing_profile';
+              throw new Error('Account has no bound identity profile');
+            }
             trace.phaseSync('applyProfileMs', () => {
-              applyDeviceProfileBestEffort(targetProfile, appTarget);
+              applyDeviceProfile(targetProfile, appTarget);
             });
           }
         } else {

--- a/src/tests/unit/switch-flow-agy.test.ts
+++ b/src/tests/unit/switch-flow-agy.test.ts
@@ -125,6 +125,32 @@ describe('executeSwitchFlow for agy CLI', () => {
     );
   });
 
+  it('fails before starting a credential-store-backed GUI target without an identity profile', async () => {
+    const performSwitch = vi.fn(async () => undefined);
+
+    await expect(
+      executeSwitchFlow({
+        scope: 'cloud',
+        appTarget: 'classic',
+        targetProfile: null,
+        applyFingerprint: true,
+        useCredentialStore: true,
+        processExitTimeoutMs: 10000,
+        performSwitch,
+      }),
+    ).rejects.toThrow('Account has no bound identity profile');
+
+    expect(performSwitch).toHaveBeenCalledTimes(1);
+    expect(applyDeviceProfile).not.toHaveBeenCalled();
+    expect(startAntigravity).not.toHaveBeenCalled();
+    expect(recordSwitchSuccess).not.toHaveBeenCalled();
+    expect(recordSwitchFailure).toHaveBeenCalledWith(
+      'cloud',
+      'missing_bound_profile',
+      'Account has no bound identity profile',
+    );
+  });
+
   it('applies the CLI device profile best-effort after credential-store switching', async () => {
     const performSwitch = vi.fn(async () => undefined);
     const afterSwitchSuccess = vi.fn(async () => undefined);

--- a/src/tests/unit/switch-flow-agy.test.ts
+++ b/src/tests/unit/switch-flow-agy.test.ts
@@ -80,27 +80,32 @@ describe('executeSwitchFlow for agy CLI', () => {
     expect(recordSwitchFailure).not.toHaveBeenCalled();
   });
 
-  it('continues when device profile apply fails for credential-store-backed GUI targets', async () => {
+  it('fails when device profile apply fails for credential-store-backed GUI targets', async () => {
     const performSwitch = vi.fn(async () => undefined);
+    const afterSwitchSuccess = vi.fn(async () => undefined);
     const targetProfile = {
       machineId: 'machine-id',
       macMachineId: 'mac-machine-id',
       devDeviceId: 'dev-device-id',
       sqmId: 'sqm-id',
     };
+    const applyError = new Error('storage_write_failed:parse_failed');
     applyDeviceProfile.mockImplementationOnce(() => {
-      throw new Error('storage_write_failed:parse_failed');
+      throw applyError;
     });
 
-    await executeSwitchFlow({
-      scope: 'cloud',
-      appTarget: 'classic',
-      targetProfile,
-      applyFingerprint: true,
-      useCredentialStore: true,
-      processExitTimeoutMs: 10000,
-      performSwitch,
-    });
+    await expect(
+      executeSwitchFlow({
+        scope: 'cloud',
+        appTarget: 'classic',
+        targetProfile,
+        applyFingerprint: true,
+        useCredentialStore: true,
+        processExitTimeoutMs: 10000,
+        performSwitch,
+        afterSwitchSuccess,
+      }),
+    ).rejects.toThrow(applyError);
 
     expect(applyDeviceProfile).toHaveBeenCalledWith(targetProfile, 'classic');
     expect(syncTelemetryServiceMachineIdValue).not.toHaveBeenCalled();
@@ -110,9 +115,14 @@ describe('executeSwitchFlow for agy CLI', () => {
     );
     expect(closeAntigravity).toHaveBeenCalledWith('classic');
     expect(waitForProcessExit).toHaveBeenCalledWith(10000, 100, 'classic');
-    expect(startAntigravity).toHaveBeenCalledWith('classic');
-    expect(recordSwitchSuccess).toHaveBeenCalledWith('cloud');
-    expect(recordSwitchFailure).not.toHaveBeenCalled();
+    expect(startAntigravity).not.toHaveBeenCalled();
+    expect(afterSwitchSuccess).not.toHaveBeenCalled();
+    expect(recordSwitchSuccess).not.toHaveBeenCalled();
+    expect(recordSwitchFailure).toHaveBeenCalledWith(
+      'cloud',
+      'apply_device_profile_failed',
+      applyError.message,
+    );
   });
 
   it('applies the CLI device profile best-effort after credential-store switching', async () => {


### PR DESCRIPTION
## Summary
- stop credential-store-backed GUI switches when the identity profile is missing or cannot be applied
- prevent the application from restarting after an incompatible credential/profile switch
- record a stable missing-profile failure reason for observability

## Validation
- src/tests/unit/switch-flow-agy.test.ts (5 tests)
- TypeScript type-check
- targeted ESLint