### PR TITLE
fix(security): redact conversational and OAuth config logs

### DIFF
--- a/src/modules/cloud-account/services/OAuthClientRegistryService.ts
+++ b/src/modules/cloud-account/services/OAuthClientRegistryService.ts
@@ -67,7 +67,7 @@ function buildOAuthClientRegistry(): OAuthClientRegistry {
       const parts = trimmed.split('|').map((part) => part.trim());
       if (parts.length < 3) {
         logger.warn(
-          `[OAuthClientRegistryService] Ignored invalid OAuth client entry in ${OAUTH_CLIENTS_ENV}: ${trimmed}`,
+          `[OAuthClientRegistryService] Ignored invalid OAuth client entry in ${OAUTH_CLIENTS_ENV}`,
         );
         continue;
       }
@@ -77,7 +77,7 @@ function buildOAuthClientRegistry(): OAuthClientRegistry {
       const clientSecret = parts[2];
       if (key === '' || clientId === '' || clientSecret === '') {
         logger.warn(
-          `[OAuthClientRegistryService] Ignored incomplete OAuth client entry in ${OAUTH_CLIENTS_ENV}: ${trimmed}`,
+          `[OAuthClientRegistryService] Ignored incomplete OAuth client entry in ${OAUTH_CLIENTS_ENV}`,
         );
         continue;
       }

--- a/src/shared/security/sensitiveDataMasking.ts
+++ b/src/shared/security/sensitiveDataMasking.ts
@@ -34,6 +34,12 @@ const SENSITIVE_KEYS = [
   'pin',
   'verificationcode',
   'verification_code',
+  'prompt',
+  'messages',
+  'content',
+  'instructions',
+  'tool_output',
+  'tooloutput',
 ];
 
 const CIRCULAR_PLACEHOLDER = '[Circular]';

--- a/src/tests/unit/oauth-client-registry-security.test.ts
+++ b/src/tests/unit/oauth-client-registry-security.test.ts
@@ -42,9 +42,8 @@ describe('OAuth client registry logging', () => {
     const secret = 'custom-client-secret-value';
     process.env[OAUTH_CLIENTS_ENV] = `|client-id|${secret}|Custom Client`;
 
-    const { OAuthClientRegistryService } = await import(
-      '@/modules/cloud-account/services/OAuthClientRegistryService'
-    );
+    const { OAuthClientRegistryService } =
+      await import('@/modules/cloud-account/services/OAuthClientRegistryService');
 
     OAuthClientRegistryService.listOAuthClients();
 

--- a/src/tests/unit/oauth-client-registry-security.test.ts
+++ b/src/tests/unit/oauth-client-registry-security.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/logging/logger', () => ({
+  logger: mockLogger,
+}));
+
+const OAUTH_CLIENTS_ENV = 'ANTIGRAVITY_OAUTH_CLIENTS';
+const ACTIVE_OAUTH_CLIENT_ENV = 'ANTIGRAVITY_OAUTH_CLIENT_KEY';
+
+const originalOauthClients = process.env[OAUTH_CLIENTS_ENV];
+const originalActiveOauthClient = process.env[ACTIVE_OAUTH_CLIENT_ENV];
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+describe('OAuth client registry logging', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env[ACTIVE_OAUTH_CLIENT_ENV];
+  });
+
+  afterEach(() => {
+    restoreEnv(OAUTH_CLIENTS_ENV, originalOauthClients);
+    restoreEnv(ACTIVE_OAUTH_CLIENT_ENV, originalActiveOauthClient);
+  });
+
+  it('does not log client secrets from incomplete OAuth client entries', async () => {
+    const secret = 'custom-client-secret-value';
+    process.env[OAUTH_CLIENTS_ENV] = `|client-id|${secret}|Custom Client`;
+
+    const { OAuthClientRegistryService } = await import(
+      '@/modules/cloud-account/services/OAuthClientRegistryService'
+    );
+
+    OAuthClientRegistryService.listOAuthClients();
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      '[OAuthClientRegistryService] Ignored incomplete OAuth client entry in ANTIGRAVITY_OAUTH_CLIENTS',
+    );
+    expect(mockLogger.warn.mock.calls.flat().join(' ')).not.toContain(secret);
+  });
+});

--- a/src/tests/unit/sensitive-data-masking.test.ts
+++ b/src/tests/unit/sensitive-data-masking.test.ts
@@ -16,6 +16,24 @@ describe('sensitive data masking', () => {
       expect(sanitizeObject({ refresh_token: 'rt' })).toEqual({ refresh_token: '[REDACTED]' });
     });
 
+    it('masks conversational and tool payloads', () => {
+      const sanitized = sanitizeObject({
+        prompt: 'private prompt',
+        messages: [{ role: 'user', content: 'private message' }],
+        instructions: 'private instructions',
+        tool_output: 'private tool result',
+        metadata: { content: 'private nested content' },
+      });
+
+      expect(sanitized).toEqual({
+        prompt: '[REDACTED]',
+        messages: '[REDACTED]',
+        instructions: '[REDACTED]',
+        tool_output: '[REDACTED]',
+        metadata: { content: '[REDACTED]' },
+      });
+    });
+
     it('masks nested keys', () => {
       expect(
         sanitizeObject({
@@ -147,6 +165,22 @@ describe('sensitive data masking', () => {
       expect(out).toContain('"user":"a"');
       expect(out).toContain('"password":"[REDACTED]"');
       expect(() => JSON.parse(out)).not.toThrow();
+    });
+
+    it('does not retain conversational content in packet logs', () => {
+      const out = safeStringifyPacket({
+        method: 'chat',
+        input: {
+          messages: [{ role: 'user', content: 'customer secret' }],
+          instructions: 'internal system prompt',
+        },
+      });
+
+      expect(out).toContain('"method":"chat"');
+      expect(out).not.toContain('customer secret');
+      expect(out).not.toContain('internal system prompt');
+      expect(out).toContain('"messages":"[REDACTED]"');
+      expect(out).toContain('"instructions":"[REDACTED]"');
     });
   });
 });

--- a/src/tests/unit/upstream-4xx-capture.test.ts
+++ b/src/tests/unit/upstream-4xx-capture.test.ts
@@ -226,10 +226,28 @@ describe('upstream 4xx capture', () => {
     expect(files).not.toContain(path.basename(existingFiles[0]));
   });
 
-  it('replaces an oversized capture with a bounded diagnostic summary', async () => {
+  it('redacts conversation content from captured upstream requests', async () => {
+    const privatePrompt = 'private user conversation';
     await writeCapture({
       upstreamRequest: {
-        request: { model: 'upstream-model', prompt: 'large prompt! '.repeat(200_000) },
+        request: { model: 'upstream-model', prompt: privatePrompt },
+      },
+    });
+
+    const [file] = await captureFiles();
+    const content = await fs.readFile(path.join(agentDirectory, CAPTURES_DIRECTORY, file), 'utf-8');
+
+    expect(content).not.toContain(privatePrompt);
+    expect(content).toContain('"prompt": "[REDACTED]"');
+  });
+
+  it('replaces an oversized non-sensitive capture with a bounded diagnostic summary', async () => {
+    await writeCapture({
+      upstreamRequest: {
+        request: {
+          model: 'upstream-model',
+          diagnostic_blob: 'large diagnostic payload! '.repeat(200_000),
+        },
       },
     });
 


### PR DESCRIPTION
## Summary
- redact prompts, messages, content, instructions, and tool outputs from packet logs
- avoid echoing OAuth client identifiers or secrets from invalid environment configuration
- retain safe operation metadata for diagnostics

## Validation
- sensitive-data masking and OAuth client registry tests (21 tests)
- TypeScript type-check
- targeted ESLint