### PR TITLE
fix(proxy): preserve active cache entries

### DIFF
--- a/src/modules/proxy-gateway/antigravity/SignatureStore.ts
+++ b/src/modules/proxy-gateway/antigravity/SignatureStore.ts
@@ -118,7 +118,7 @@ class SignatureStoreImpl {
       );
     }
 
-    this.signaturesBySession.set(sessionKey, bucket);
+    this.touchSession(sessionKey, bucket, now);
     this.evictOverflowSessions();
   }
 
@@ -135,6 +135,7 @@ class SignatureStoreImpl {
         this.signaturesBySession.delete(sessionKey);
         return null;
       }
+      this.touchSession(sessionKey, stored);
       let latestMessageCount = -1;
       let latestSignature: string | null = null;
       for (const [messageCount, cached] of stored.signaturesByMessageCount) {
@@ -184,6 +185,7 @@ class SignatureStoreImpl {
       this.signaturesBySession.delete(sessionKey);
       return null;
     }
+    this.touchSession(sessionKey, stored);
     return stored.signaturesByMessageCount.get(messageCount)?.signature ?? null;
   }
 
@@ -263,6 +265,16 @@ class SignatureStoreImpl {
       }
       this.signaturesByToolCallKey.delete(oldestToolCallKey);
     }
+  }
+
+  private touchSession(
+    sessionKey: string,
+    stored: SessionSignatureBucket,
+    updatedAt = Date.now(),
+  ): void {
+    stored.updatedAt = updatedAt;
+    this.signaturesBySession.delete(sessionKey);
+    this.signaturesBySession.set(sessionKey, stored);
   }
 
   private evictExpiredSessions(): void {

--- a/src/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.store.ts
+++ b/src/modules/proxy-gateway/server/modules/gemini/explicit-context-cache.store.ts
@@ -170,6 +170,9 @@ export class ExplicitContextCacheManager {
       this.updateActiveEntryCount();
       return null;
     }
+
+    this.entries.delete(key);
+    this.entries.set(key, entry);
     return entry.name;
   }
 

--- a/src/tests/unit/explicit-context-cache.test.ts
+++ b/src/tests/unit/explicit-context-cache.test.ts
@@ -64,6 +64,42 @@ describe('ExplicitContextCacheManager', () => {
     });
   });
 
+  it('keeps recently used cache entries when capacity eviction runs', async () => {
+    const manager = new ExplicitContextCacheManager();
+    const candidates = Array.from({ length: 501 }, (_, index) =>
+      createCandidate(manager, `-capacity-${index}`),
+    );
+
+    for (let index = 0; index < 500; index += 1) {
+      await manager.resolve(candidates[index], async () => ({
+        expireTime: '2099-01-01T00:00:00Z',
+        name: `projects/project-a/locations/us-central1/cachedContents/cache-${index}`,
+      }));
+    }
+
+    const firstCreate = vi.fn(async () => ({
+      expireTime: '2099-01-01T00:00:00Z',
+      name: 'projects/project-a/locations/us-central1/cachedContents/cache-first-recreated',
+    }));
+    await manager.resolve(candidates[0], firstCreate);
+    expect(firstCreate).not.toHaveBeenCalled();
+
+    await manager.resolve(candidates[500], async () => ({
+      expireTime: '2099-01-01T00:00:00Z',
+      name: 'projects/project-a/locations/us-central1/cachedContents/cache-500',
+    }));
+
+    await manager.resolve(candidates[0], firstCreate);
+    expect(firstCreate).not.toHaveBeenCalled();
+
+    const secondCreate = vi.fn(async () => ({
+      expireTime: '2099-01-01T00:00:00Z',
+      name: 'projects/project-a/locations/us-central1/cachedContents/cache-second-recreated',
+    }));
+    await manager.resolve(candidates[1], secondCreate);
+    expect(secondCreate).toHaveBeenCalledTimes(1);
+  });
+
   it('prunes expired failure cooldowns while resolving new cache candidates', async () => {
     vi.useFakeTimers();
     try {

--- a/src/tests/unit/signature-store-lru.test.ts
+++ b/src/tests/unit/signature-store-lru.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SignatureStore } from '@/modules/proxy-gateway/antigravity/SignatureStore';
+
+describe('SignatureStore session eviction', () => {
+  afterEach(() => {
+    SignatureStore.clear();
+  });
+
+  it('preserves an active old session when the session cache exceeds capacity', () => {
+    for (let index = 0; index < 500; index += 1) {
+      SignatureStore.store(`signature-${index}`, `session-${index}`, 1);
+    }
+
+    expect(SignatureStore.get('session-0')).toBe('signature-0');
+
+    SignatureStore.store('signature-500', 'session-500', 1);
+
+    expect(SignatureStore.get('session-0')).toBe('signature-0');
+    expect(SignatureStore.get('session-1')).toBeNull();
+    expect(SignatureStore.get('session-500')).toBe('signature-500');
+  });
+});


### PR DESCRIPTION
## Summary
- refresh explicit Gemini context-cache entries on reads
- refresh normal Thought Signature sessions on reads and updates
- preserve active entries during bounded-cache eviction

## Validation
- context-cache and SignatureStore LRU tests (6 tests)
- TypeScript type-check
- targeted ESLint