### PR TITLE
fix(proxy): preserve malformed model-path captures

### DIFF
--- a/src/modules/proxy-gateway/server/common/upstream-4xx-capture.service.ts
+++ b/src/modules/proxy-gateway/server/common/upstream-4xx-capture.service.ts
@@ -187,5 +187,10 @@ function findClientModel(body: unknown, endpoint: string | undefined): string | 
   if (!match) {
     return null;
   }
-  return decodeURIComponent(match[1]);
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
 }

--- a/src/tests/unit/upstream-4xx-capture.test.ts
+++ b/src/tests/unit/upstream-4xx-capture.test.ts
@@ -86,6 +86,27 @@ describe('upstream 4xx capture', () => {
     });
   });
 
+  it('preserves a capture when the client model path has malformed percent encoding', async () => {
+    const capture = new Upstream4xxCaptureService();
+    await runWithUpstreamCaptureContext(
+      captureContext({ body: {}, endpoint: '/v1beta/models/bad%ZZ:generateContent' }),
+      () =>
+        capture.capture({
+          endpoint: 'https://cloudcode-pa.googleapis.com/v1internal:generateContent',
+          status: 400,
+          upstreamErrorBody: { error: { message: 'rejected' } },
+          upstreamRequest: { request: { model: 'upstream-model' } },
+        }),
+    );
+
+    const files = await captureFiles();
+    expect(files).toHaveLength(1);
+    const document = JSON.parse(
+      await fs.readFile(path.join(agentDirectory, CAPTURES_DIRECTORY, files[0]), 'utf-8'),
+    ) as { metadata?: { client_visible_model?: string } };
+    expect(document.metadata?.client_visible_model).toBe('bad%ZZ');
+  });
+
   it('does not write a capture for a 2xx response', async () => {
     await writeCapture({ status: 200 });
 


### PR DESCRIPTION
## Summary
- preserve upstream 4xx captures when a client model path contains malformed percent encoding
- fall back to the raw model segment instead of letting URL decoding abort diagnostics

## Validation
- src/tests/unit/upstream-4xx-capture.test.ts (11 passed, 1 existing skipped)
- TypeScript type-check
- targeted ESLint