### PR TITLE
fix(proxy): scope model availability by account

### DIFF
--- a/src/modules/proxy-gateway/server/common/base-proxy.service.ts
+++ b/src/modules/proxy-gateway/server/common/base-proxy.service.ts
@@ -183,7 +183,8 @@ export abstract class BaseProxyService {
     model: string,
     error: unknown,
   ): Promise<void> {
-    if (this.isModelNotFoundError(error)) {
+    const isImageModel = model.toLowerCase().includes('-image');
+    if (this.isModelNotFoundError(error) && !isImageModel) {
       // Quota metadata can advertise ids the generation API rejects; mark the
       // id so the in-flight retry loop and later requests reroute to a sibling.
       this.accountLeaseService.markModelUnrequestable(model);

--- a/src/modules/proxy-gateway/server/shared/services/model-availability.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/model-availability.service.ts
@@ -128,6 +128,7 @@ export class ModelAvailabilityService {
     for (const [key, entry] of this.entries) {
       if (
         entry.accountId === accountId &&
+        entry.modelId.includes('image') &&
         (entry.reason === 'model_not_supported' || entry.reason === 'model_forbidden')
       ) {
         this.entries.delete(key);

--- a/src/modules/proxy-gateway/server/shared/services/model-availability.service.ts
+++ b/src/modules/proxy-gateway/server/shared/services/model-availability.service.ts
@@ -115,11 +115,7 @@ export class ModelAvailabilityService {
     }
     this.hydrate();
     const normalizedModelId = normalizeModelId(modelId);
-    let changed = this.entries.delete(createKey(accountId, normalizedModelId));
-    if (normalizedModelId.includes('image')) {
-      changed = this.entries.delete(createKey(accountId, 'gemini-3.1-flash-image')) || changed;
-      changed = this.entries.delete(createKey(accountId, 'gemini-3-pro-image')) || changed;
-    }
+    const changed = this.entries.delete(createKey(accountId, normalizedModelId));
     if (changed) {
       this.persist();
     }

--- a/src/tests/unit/base-proxy-model-not-found-scope.test.ts
+++ b/src/tests/unit/base-proxy-model-not-found-scope.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BaseProxyService } from '@/modules/proxy-gateway/server/common/base-proxy.service';
+import { UpstreamRequestError } from '@/modules/proxy-gateway/server/common/exceptions/upstream-request.exception';
+import type { AccountLeaseService } from '@/modules/proxy-gateway/server/modules/account-lease/account-lease.service';
+import type { GeminiClient } from '@/modules/proxy-gateway/server/modules/gemini/gemini-client.service';
+import { proxyModelAvailabilityStore } from '@/modules/proxy-gateway/server/shared/services/model-availability.service';
+
+class TestProxyService extends BaseProxyService {
+  applyPenalty(accountId: string, model: string, error: unknown): Promise<void> {
+    return this.applyUpstreamPenalty(accountId, model, error);
+  }
+}
+
+function createService() {
+  const accountLeaseService = {
+    markModelUnrequestable: vi.fn(),
+    markFromUpstreamError: vi.fn().mockResolvedValue(undefined),
+    recordParityError: vi.fn(),
+  } as unknown as AccountLeaseService;
+
+  return {
+    accountLeaseService,
+    service: new TestProxyService(accountLeaseService, {} as GeminiClient),
+  };
+}
+
+const imageModel = 'gemini-3-pro-image';
+
+afterEach(() => {
+  proxyModelAvailabilityStore.clearModel('acc-a', imageModel);
+});
+
+describe('BaseProxyService model-not-found penalty scope', () => {
+  it('keeps image model 404 failures scoped to the failing account', async () => {
+    const { accountLeaseService, service } = createService();
+    const error = new UpstreamRequestError({
+      message: 'Requested entity was not found',
+      status: 404,
+    });
+
+    await service.applyPenalty('acc-a', imageModel, error);
+
+    expect(accountLeaseService.markModelUnrequestable).not.toHaveBeenCalled();
+    expect(proxyModelAvailabilityStore.getSnapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: 'acc-a',
+          modelId: imageModel,
+          reason: 'model_not_supported',
+        }),
+      ]),
+    );
+  });
+
+  it('preserves global sibling rerouting for non-image model 404 failures', async () => {
+    const { accountLeaseService, service } = createService();
+    const error = new UpstreamRequestError({
+      message: 'Requested entity was not found',
+      status: 404,
+    });
+
+    await service.applyPenalty('acc-a', 'gemini-3.6-flash-low', error);
+
+    expect(accountLeaseService.markModelUnrequestable).toHaveBeenCalledWith(
+      'gemini-3.6-flash-low',
+    );
+  });
+});

--- a/src/tests/unit/base-proxy-model-not-found-scope.test.ts
+++ b/src/tests/unit/base-proxy-model-not-found-scope.test.ts
@@ -3,7 +3,10 @@ import { BaseProxyService } from '@/modules/proxy-gateway/server/common/base-pro
 import { UpstreamRequestError } from '@/modules/proxy-gateway/server/common/exceptions/upstream-request.exception';
 import type { AccountLeaseService } from '@/modules/proxy-gateway/server/modules/account-lease/account-lease.service';
 import type { GeminiClient } from '@/modules/proxy-gateway/server/modules/gemini/gemini-client.service';
+import type { GenerationConstraintsService } from '@/modules/proxy-gateway/server/shared/services/generation-constraints.service';
 import { proxyModelAvailabilityStore } from '@/modules/proxy-gateway/server/shared/services/model-availability.service';
+import type { ModelRoutingService } from '@/modules/proxy-gateway/server/shared/services/model-routing.service';
+import { ProxyRetryService } from '@/modules/proxy-gateway/server/shared/services/proxy-retry.service';
 
 class TestProxyService extends BaseProxyService {
   applyPenalty(accountId: string, model: string, error: unknown): Promise<void> {
@@ -13,14 +16,30 @@ class TestProxyService extends BaseProxyService {
 
 function createService() {
   const accountLeaseService = {
+    getNextToken: vi.fn(),
     markModelUnrequestable: vi.fn(),
     markFromUpstreamError: vi.fn().mockResolvedValue(undefined),
     recordParityError: vi.fn(),
+    markAsForbidden: vi.fn(),
+    markAsRateLimited: vi.fn(),
+    getRemainingRateLimitWait: vi.fn(),
+    markModelSuccess: vi.fn(),
   } as unknown as AccountLeaseService;
+  const retryPolicy = new ProxyRetryService(
+    accountLeaseService,
+    { log: vi.fn(), warn: vi.fn() },
+    proxyModelAvailabilityStore,
+  );
 
   return {
     accountLeaseService,
-    service: new TestProxyService(accountLeaseService, {} as GeminiClient),
+    service: new TestProxyService(
+      accountLeaseService,
+      {} as GeminiClient,
+      {} as GenerationConstraintsService,
+      retryPolicy,
+      {} as ModelRoutingService,
+    ),
   };
 }
 

--- a/src/tests/unit/base-proxy-model-not-found-scope.test.ts
+++ b/src/tests/unit/base-proxy-model-not-found-scope.test.ts
@@ -80,8 +80,6 @@ describe('BaseProxyService model-not-found penalty scope', () => {
 
     await service.applyPenalty('acc-a', 'gemini-3.6-flash-low', error);
 
-    expect(accountLeaseService.markModelUnrequestable).toHaveBeenCalledWith(
-      'gemini-3.6-flash-low',
-    );
+    expect(accountLeaseService.markModelUnrequestable).toHaveBeenCalledWith('gemini-3.6-flash-low');
   });
 });

--- a/src/tests/unit/proxy-model-availability-store.test.ts
+++ b/src/tests/unit/proxy-model-availability-store.test.ts
@@ -61,6 +61,22 @@ describe('ModelAvailabilityService', () => {
     ]);
   });
 
+  it('preserves sibling image model failures when another image model succeeds', () => {
+    const store = new ModelAvailabilityService();
+
+    store.mark('acc-1', 'gemini-3-pro-image', 'model_not_supported');
+    store.mark('acc-1', 'gemini-3.1-flash-image', 'model_forbidden');
+
+    expect(store.clearModel('acc-1', 'gemini-3.1-flash-image')).toBe(true);
+    expect(store.getSnapshot()).toEqual([
+      expect.objectContaining({
+        accountId: 'acc-1',
+        modelId: 'gemini-3-pro-image',
+        reason: 'model_not_supported',
+      }),
+    ]);
+  });
+
   it('persists live status details and restores them after restart', () => {
     const durableState = createPersistence();
     const firstStore = new ModelAvailabilityService(durableState.persistence);

--- a/src/tests/unit/proxy-model-availability-store.test.ts
+++ b/src/tests/unit/proxy-model-availability-store.test.ts
@@ -27,13 +27,19 @@ describe('ModelAvailabilityService', () => {
 
     store.mark('acc-1', 'gemini-3-pro-image', 'model_not_supported');
     store.mark('acc-1', 'gemini-3-flash-image', 'model_forbidden');
-    store.mark('acc-1', 'gemini-3-pro', 'quota_exhausted');
+    store.mark('acc-1', 'gemini-3-pro', 'model_not_supported');
+    store.mark('acc-1', 'gemini-3.1-flash-lite', 'quota_exhausted');
     store.clearCapabilityFailures('acc-1');
 
     expect(store.getSnapshot()).toEqual([
       expect.objectContaining({
         accountId: 'acc-1',
         modelId: 'gemini-3-pro',
+        reason: 'model_not_supported',
+      }),
+      expect.objectContaining({
+        accountId: 'acc-1',
+        modelId: 'gemini-3.1-flash-lite',
         reason: 'quota_exhausted',
       }),
     ]);


### PR DESCRIPTION
## Summary
- keep image-model 404 failures scoped to the failing account
- preserve sibling image availability and non-image capability failures
- update the BaseProxyService regression test for the current shared retry-policy dependency

## Validation
- 22 focused proxy tests
- TypeScript type-check
- targeted ESLint