### PR TITLE
Stop the keychain password prompt on every account switch

### DIFF
--- a/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
+++ b/src/modules/cloud-account/persistence/antigravityCredentialStore.ts
@@ -276,18 +276,33 @@ export function writeAntigravityCredentialStoreToken(
   }
 }
 
+function credentialStoreItemExists(): boolean {
+  // `find-generic-password` reads only the item's attributes, not its secret, so it does not prompt
+  // even when the ACL is restrictive. Exit status 0 means the item is present.
+  const result = spawnSync(
+    'security',
+    ['find-generic-password', '-s', 'gemini', '-a', 'antigravity'],
+    { stdio: 'ignore' },
+  );
+  return result.status === 0;
+}
+
 function writeToSystemCredentialStore(payload: string): void {
   if (process.platform === 'darwin') {
     const value = `go-keyring-base64:${Buffer.from(payload, 'utf-8').toString('base64')}`;
-    execFileSync(
-      'security',
-      ['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-A', '-U', '-w'],
-      {
-        input: `${value}\n`,
-        encoding: 'utf-8',
-        stdio: ['pipe', 'ignore', 'ignore'],
-      },
-    );
+    // `-A` sets the item's access-control list to "all applications". macOS treats writing the ACL
+    // as a change that needs the login-keychain password, and `-U` reapplies it on every update, so
+    // each account switch pops a password prompt. Only pass `-A` when the item does not exist yet;
+    // afterwards update the stored value without touching the ACL, which does not prompt.
+    const alreadyExists = credentialStoreItemExists();
+    const args = alreadyExists
+      ? ['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-U', '-w']
+      : ['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-A', '-U', '-w'];
+    execFileSync('security', args, {
+      input: `${value}\n`,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'ignore', 'ignore'],
+    });
     return;
   }
 

--- a/src/tests/unit/antigravity-credential-store-write.test.ts
+++ b/src/tests/unit/antigravity-credential-store-write.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
   setSecret: vi.fn(),
   deleteCredential: vi.fn(),
   withTarget: vi.fn(),
@@ -32,8 +33,10 @@ vi.mock('child_process', async (importOriginal) => {
     default: {
       ...actual,
       execFileSync: mocks.execFileSync,
+      spawnSync: mocks.spawnSync,
     },
     execFileSync: mocks.execFileSync,
+    spawnSync: mocks.spawnSync,
   };
 });
 
@@ -50,6 +53,9 @@ describe('writeAntigravityCredentialStoreToken', () => {
   beforeEach(() => {
     vi.resetModules();
     mocks.execFileSync.mockReset();
+    mocks.spawnSync.mockReset();
+    // Default: the keychain item does not exist yet, so writes take the create path.
+    mocks.spawnSync.mockReturnValue({ status: 1 });
     mocks.setSecret.mockReset();
     mocks.deleteCredential.mockReset();
     mocks.withTarget.mockReset();
@@ -66,7 +72,8 @@ describe('writeAntigravityCredentialStoreToken', () => {
     setPlatform(originalPlatform);
   });
 
-  it('updates the macOS keychain item without exposing the credential in process arguments', async () => {
+  it('sets the ACL with -A when first creating the macOS keychain item, without exposing the credential in process arguments', async () => {
+    mocks.spawnSync.mockReturnValue({ status: 1 }); // item does not exist yet
     const { writeAntigravityCredentialStoreToken } =
       await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
 
@@ -92,6 +99,29 @@ describe('writeAntigravityCredentialStoreToken', () => {
     expect(args.join(' ')).not.toContain('refresh-token');
     expect(args).not.toContain('delete-generic-password');
     expect(mocks.writeGoogleOAuthCredentials).not.toHaveBeenCalled();
+  });
+
+  it('updates an existing macOS keychain item without -A so it does not reprompt for ACL changes', async () => {
+    mocks.spawnSync.mockReturnValue({ status: 0 }); // item already exists
+    const { writeAntigravityCredentialStoreToken } =
+      await import('@/modules/cloud-account/persistence/antigravityCredentialStore');
+
+    writeAntigravityCredentialStoreToken({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expiry_timestamp: 1_900_000_000,
+    });
+
+    // Existence is probed with a non-prompting attribute read.
+    expect(mocks.spawnSync).toHaveBeenCalledWith(
+      'security',
+      ['find-generic-password', '-s', 'gemini', '-a', 'antigravity'],
+      expect.objectContaining({ stdio: 'ignore' }),
+    );
+    expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
+    const args = mocks.execFileSync.mock.calls[0][1] as string[];
+    expect(args).toEqual(['add-generic-password', '-s', 'gemini', '-a', 'antigravity', '-U', '-w']);
+    expect(args).not.toContain('-A');
   });
 
   it('syncs generic Google OAuth files only when the caller marks an explicit Agy switch', async () => {


### PR DESCRIPTION
## The problem

Every time an account is switched, macOS pops a keychain password prompt: "security wants to change access permissions of the gemini item in your keychain." Clicking Allow works for that one switch, but the prompt comes back on the next switch, and the dialog offers no "Always Allow" option, so there is no way to make it stop from the UI.

The cause is the command used to write the token in `writeToSystemCredentialStore` (`antigravityCredentialStore.ts`):

```
security add-generic-password -s gemini -a antigravity -A -U -w
```

`-A` sets the item's access-control list to "all applications". macOS treats writing the ACL as a change that requires the login-keychain password, and `-U` reapplies it on every write. So each switch rewrites the ACL and triggers the password dialog. This is the "change access permissions" prompt specifically, which is why clicking Allow never sticks: it is authorizing an ACL modification, not granting an app ongoing access.

## The fix

Only pass `-A` when the item is being created for the first time. After that, update the stored value without touching the ACL.

Existence is checked with a non-prompting attribute read (`find-generic-password`, which reads the item's metadata, not its secret). If the item already exists, the write drops `-A` and uses `-U` alone, which updates the value in place and does not modify the ACL, so nothing needs authorizing. First-time setup still uses `-A` so the CLI and other clients can read the item.

## Behavior after the change

- First run on a machine: item is created with `-A` as before, one prompt at most.
- Every subsequent switch: value is updated with no ACL change, no prompt.
- Non-macOS paths (Linux `secret-tool`, native keyring) are untouched.

Verified by hand: after installing the change, switching accounts no longer shows the keychain dialog.

## Tests

Updated `antigravity-credential-store-write.test.ts`:

- the create path (item missing) still asserts `-A -U`,
- a new case for the update path (item present) asserts the command is `-U` only with no `-A`, and that existence is probed with the non-prompting `find-generic-password` read.

`spawnSync` is mocked alongside `execFileSync` so the suite does not touch the real keychain. `type-check`, `lint`, and `format` pass.
